### PR TITLE
Allow the encoding to be generated on the fly in `solve()`

### DIFF
--- a/qrao/quantum_random_access_optimizer.py
+++ b/qrao/quantum_random_access_optimizer.py
@@ -12,7 +12,7 @@
 
 """Quantum Random Access Optimizer."""
 
-from typing import Union, List, Tuple, Optional
+from typing import Union, List, Tuple, Optional, Callable
 import time
 
 import numpy as np
@@ -114,6 +114,10 @@ class QuantumRandomAccessOptimizer(OptimizationAlgorithm):
         min_eigen_solver: MinimumEigensolver,
         rounding_scheme: Optional[RoundingScheme] = None,
         encoding: Optional[QuantumRandomAccessEncoding] = None,
+        *,
+        encoding_factory: Callable[
+            [], QuantumRandomAccessEncoding
+        ] = QuantumRandomAccessEncoding,
     ):
         """
         Args:
@@ -130,6 +134,8 @@ class QuantumRandomAccessOptimizer(OptimizationAlgorithm):
         """
         self.min_eigen_solver = min_eigen_solver
         self.encoding = encoding
+        if encoding is None:
+            self.encoding_factory = encoding_factory
         if rounding_scheme is None:
             rounding_scheme = SemideterministicRounding()
         self.rounding_scheme = rounding_scheme
@@ -220,7 +226,7 @@ class QuantumRandomAccessOptimizer(OptimizationAlgorithm):
     ) -> Tuple[MinimumEigensolverResult, RoundingContext]:
         problem = self.__get_problem(problem)
         if self.encoding is None:
-            encoding = QuantumRandomAccessEncoding()
+            encoding = self.encoding_factory()
             encoding.encode(problem)
         else:
             encoding = self.encoding

--- a/tests/test_quantum_random_access_optimizer.py
+++ b/tests/test_quantum_random_access_optimizer.py
@@ -14,6 +14,8 @@
 
 from unittest import TestCase
 
+from functools import partial
+
 import numpy as np
 
 from qiskit import Aer
@@ -173,6 +175,24 @@ class TestQuantumRandomAccessOptimizer(TestCase):
             quantum_instance=relaxed_qi,
         )
         qrao = QuantumRandomAccessOptimizer(vqe)
+        results = qrao.solve(self.problem)
+        self.assertIsInstance(results.relaxed_results, MinimumEigensolverResult)
+        self.assertIsInstance(results.rounding_results, RoundingResult)
+
+    def test_solve_with_encoding_factory(self):
+        """Test that solve(problem) can work if no encoding provided in constructor"""
+        relaxed_qi = QuantumInstance(
+            backend=Aer.get_backend("aer_simulator_statevector"), shots=100
+        )
+        vqe = VQE(
+            ansatz=self.ansatz,
+            optimizer=SPSA(maxiter=1, learning_rate=0.01, perturbation=0.1),
+            quantum_instance=relaxed_qi,
+        )
+        qrao = QuantumRandomAccessOptimizer(
+            vqe,
+            encoding_factory=partial(QuantumRandomAccessEncoding, max_vars_per_qubit=2),
+        )
         results = qrao.solve(self.problem)
         self.assertIsInstance(results.relaxed_results, MinimumEigensolverResult)
         self.assertIsInstance(results.rounding_results, RoundingResult)

--- a/tests/test_quantum_random_access_optimizer.py
+++ b/tests/test_quantum_random_access_optimizer.py
@@ -162,6 +162,35 @@ class TestQuantumRandomAccessOptimizer(TestCase):
         self.assertIsInstance(results.relaxed_results, MinimumEigensolverResult)
         self.assertIsInstance(results.rounding_results, RoundingResult)
 
+    def test_solve_on_late_specified_problem(self):
+        """Test that solve(problem) can work if no encoding provided in constructor"""
+        relaxed_qi = QuantumInstance(
+            backend=Aer.get_backend("aer_simulator_statevector"), shots=100
+        )
+        vqe = VQE(
+            ansatz=self.ansatz,
+            optimizer=SPSA(maxiter=1, learning_rate=0.01, perturbation=0.1),
+            quantum_instance=relaxed_qi,
+        )
+        qrao = QuantumRandomAccessOptimizer(vqe)
+        results = qrao.solve(self.problem)
+        self.assertIsInstance(results.relaxed_results, MinimumEigensolverResult)
+        self.assertIsInstance(results.rounding_results, RoundingResult)
+
+    def test_solve_without_anything(self):
+        """Test that solve() errors without a problem nor with an encoding"""
+        relaxed_qi = QuantumInstance(
+            backend=Aer.get_backend("aer_simulator_statevector"), shots=100
+        )
+        vqe = VQE(
+            ansatz=self.ansatz,
+            optimizer=SPSA(maxiter=1, learning_rate=0.01, perturbation=0.1),
+            quantum_instance=relaxed_qi,
+        )
+        qrao = QuantumRandomAccessOptimizer(vqe)
+        with self.assertRaises(ValueError):
+            qrao.solve()
+
     def test_empty_encoding(self):
         """Test that an exception is raised if the encoding has no qubits"""
         relaxed_qi = QuantumInstance(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #9.

### Details and comments

Remaining tasks:

- [ ] Add more test coverage
- [ ] Figure out a workaround for our prior need to access `self.encoding.offset` in `solve()`.  `offset` somehow needs to make it from `solve_relaxed()` to `solve()`.  It seems like `solve_relaxed()` almost needs to return the `offset` as a third tuple element ... or, we could put it in the `RoundingContext`, but it doesn't seem to really belong there.  Potentially related to #8.



