### PR TITLE
Deprecate `encoding.offset` while incorporating it into `encoding.qubit_op`

### DIFF
--- a/docs/how_tos/check_encoding_problem_commutation.ipynb
+++ b/docs/how_tos/check_encoding_problem_commutation.ipynb
@@ -147,15 +147,14 @@
       "+ 53.99999999999999 * YIX\n",
       "+ 71.99999999999999 * YYI\n",
       "+ 104.99999999999999 * YZI\n",
-      "Offset =  -132.0\n",
+      "- 132.0 * III\n",
       "Variables encoded on each qubit:  [[0, 4], [1, 3, 5], [2]]\n"
      ]
     }
    ],
    "source": [
     "print(\"Encoded Problem:\\n=================\")\n",
-    "print(encoding.qubit_op)  # The Hamiltonian without the offset\n",
-    "print(\"Offset = \", encoding.offset)\n",
+    "print(encoding.qubit_op)  # The Hamiltonian\n",
     "print(\"Variables encoded on each qubit: \", encoding.q2vars)"
    ]
   },

--- a/qrao/encoding.py
+++ b/qrao/encoding.py
@@ -48,6 +48,7 @@ from qiskit.opflow import (
     StateFn,
     CircuitStateFn,
 )
+from qiskit.utils.deprecation import deprecate_function
 
 from qiskit_optimization.problems.quadratic_program import QuadraticProgram
 
@@ -274,7 +275,6 @@ class QuantumRandomAccessEncoding:
             raise ValueError("max_vars_per_qubit must be 1, 2, or 3") from None
 
         self._qubit_op: Optional[Union[PauliOp, PauliSumOp]] = None
-        self._offset: Optional[float] = None
         self._problem: Optional[QuadraticProgram] = None
         self._var2op: Dict[int, Tuple[int, PrimitiveOp]] = {}
         self._q2vars: List[List[int]] = []
@@ -321,15 +321,20 @@ class QuantumRandomAccessEncoding:
         return self._qubit_op
 
     @property
+    @deprecate_function(
+        "The `offset` has been incorporated directly into `qubit_op`, "
+        "obviating the need for its own property.  It will always be 0.0 "
+        "from now on and will be removed in the future."
+    )
     def offset(self) -> float:
-        if self._offset is None:
+        if self._qubit_op is None:
             raise AttributeError(
                 "No objective function has been provided from which a "
                 "qubit Hamiltonian can be constructed. Please use the "
                 "encode method if you wish to manually compile "
                 "this field."
             )
-        return self._offset
+        return 0.0
 
     @property
     def problem(self) -> QuadraticProgram:
@@ -421,7 +426,6 @@ class QuantumRandomAccessEncoding:
 
         After being called, the object will have the following attributes:
             qubit_op: The qubit operator encoding the input QuadraticProgram.
-            offset: The constant value in the encoded Hamiltonian.
             problem: The ``problem`` used for encoding.
 
         Inputs:
@@ -517,8 +521,8 @@ class QuantumRandomAccessEncoding:
                 w = quad[i, j]
                 if w != 0:
                     self._add_term(w, i, j)
+        self._add_term(offset)
 
-        self._offset = offset
         self._problem = problem
 
         # This is technically optional and can wait until the optimizer is
@@ -579,11 +583,6 @@ class EncodingCommutationVerifier:
         dvars = [int(b) for b in str_dvars]
         encoded_bitstr = encoding.state_prep(dvars)
 
-        # Offset accounts for the value of the encoded Hamiltonian's
-        # identity coefficient. This term need not be evaluated directly as
-        # Tr[I•rho] is always 1.
-        offset = encoding.offset
-
         # Evaluate Un-encoded Problem
         # ========================
         # `sense` accounts for sign flips depending on whether
@@ -595,8 +594,6 @@ class EncodingCommutationVerifier:
         # Evaluate Encoded Problem
         # ========================
         encoded_problem = encoding.qubit_op  # H
-        encoded_obj_val = (
-            np.real((~StateFn(encoded_problem) @ encoded_bitstr).eval()) + offset
-        )
+        encoded_obj_val = np.real((~StateFn(encoded_problem) @ encoded_bitstr).eval())
 
         return (str_dvars, obj_val, encoded_obj_val)

--- a/qrao/quantum_random_access_optimizer.py
+++ b/qrao/quantum_random_access_optimizer.py
@@ -50,7 +50,6 @@ class QuantumRandomAccessOptimizationResult(OptimizationResult):
         samples: Optional[List[SolutionSample]],
         relaxed_results: MinimumEigensolverResult,
         rounding_results: RoundingResult,
-        relaxed_results_offset: float,
         sense: int,
     ) -> None:
         """
@@ -73,7 +72,6 @@ class QuantumRandomAccessOptimizationResult(OptimizationResult):
         )
         self._relaxed_results = relaxed_results
         self._rounding_results = rounding_results
-        self._relaxed_results_offset = relaxed_results_offset
         assert sense in (-1, 1)
         self._sense = sense
 
@@ -92,9 +90,7 @@ class QuantumRandomAccessOptimizationResult(OptimizationResult):
 
     @property
     def relaxed_fval(self) -> float:
-        return self._sense * (
-            self._relaxed_results_offset + self.relaxed_results.eigenvalue.real
-        )
+        return self._sense * self.relaxed_results.eigenvalue.real
 
     def __repr__(self) -> str:
         lines = (
@@ -275,6 +271,5 @@ class QuantumRandomAccessOptimizer(OptimizationAlgorithm):
             status=OptimizationResultStatus.SUCCESS,
             relaxed_results=relaxed_results,
             rounding_results=rounding_results,
-            relaxed_results_offset=self.encoding.offset,
             sense=problem.objective.sense.value,
         )

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -137,11 +137,8 @@ def test_qrac_encoding_from_model():
 
     encoding = QuantumRandomAccessEncoding(3)
     with pytest.raises(AttributeError):
-        encoding.offset
-    with pytest.raises(AttributeError):
         encoding.problem
     encoding.encode(problem)
-    encoding.offset
     encoding.problem
     assert encoding.num_qubits == 1
     assert encoding.compression_ratio == 2
@@ -216,7 +213,6 @@ def test_sense():
     min_encoding.encode(get_problem(maximize=False))
 
     assert max_encoding.qubit_op == min_encoding.qubit_op
-    assert max_encoding.offset == min_encoding.offset
 
 
 def test_qrac_state_prep_1q():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Currently, the `encode()` method results in the operator being spanned across two properties: the traceless part is stored in `qubit_op`, while the constant offset is stored in `offset`.  The current separation follows the practice of `to_ising()` is Qiskit Optimization.  However, this separation seems unnecessary.  It conceptually simplifies things to store the operator entirely in `qubit_op`, as this PR proposes.

### Details and comments

This will aid in solving #8 and with #9 (via the corresponding PR, #13).