### PR TITLE
Create 03_evaluating_performance.ipynb

### DIFF
--- a/docs/tutorials/03_evaluating_performance.ipynb
+++ b/docs/tutorials/03_evaluating_performance.ipynb
@@ -1,0 +1,578 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluating Performance\n",
+    "\n",
+    "In this notebook, we'll evaluate the performance of QRAO by determining how closely it approximates the exact solution to MaxCut for 100 random 3-regular graphs. We'll also compare the performance of QRAO used with two different rounding schemes. In the process, we'll reproduce the main results of [the paper](https://arxiv.org/pdf/2111.03167.pdf) (i.e. Fig. 1)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from tqdm.notebook import tqdm\n",
+    "\n",
+    "from qiskit import Aer\n",
+    "from qiskit.utils import QuantumInstance\n",
+    "\n",
+    "from qiskit_optimization.algorithms import CplexOptimizer\n",
+    "from qiskit.algorithms.minimum_eigen_solvers import NumPyMinimumEigensolver\n",
+    "\n",
+    "from qrao import (\n",
+    "    QuantumRandomAccessEncoding,\n",
+    "    QuantumRandomAccessOptimizer,\n",
+    "    SemideterministicRounding,\n",
+    "    MagicRounding\n",
+    ")\n",
+    "\n",
+    "from qrao.utils import get_random_maxcut_qp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's start with an example: evaluating the performance of QRAO with Pauli rounding at finding the maximal cut of a random 3-regular graph with 8 nodes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we construct a random 3-regular graph with 8 nodes shown below. We define `problem` as the `QuadraticProgram` corresponding to solving MaxCut for this graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAb4AAAEuCAYAAADx63eqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAABYNUlEQVR4nO3deVxN+f8H8NdtUVmSJbuIqCyFopLKNgyDbBUlRMm+fAczGIOZwWAwDKaoUCqULcTYUrRoX7XIKEWlUEnr7Z7fH37dkbLfe89d3s/HYx4P0733nPedcXvdz85hGIYBIYQQIiPk2C6AEEIIESUKPkIIITKFgo8QQohMoeAjhBAiUyj4CCGEyBQKPkIIITKFgo8QQohMoeAjhBAiUyj4CCGEyBQKPkIIITKFgo8QQohMoeAjhBAiUyj4CCGEyBQKPkIIITKFgo8QQohMoeAjhBAiUyj4CCGEyBQKPkIIITKFgo8QQohMoeAjhBAiUyj4CCGEyBQKPkIIITJFge0CCJEFRWVV8I/JRVp+KUoruVBVVoBOB1VYGXRBm+ZKbJdHiEzhMAzDsF0EIdIqIacYB29nIjijEABQxeXxH1NWkAMDYLi2OhZbaEG/qxo7RRIiYyj4CBGSExFZ2BqYhkpuLT70KeNwAGUFeWwYr4NZxt1FVh8hsoq6OgkRgjehl4qKGt5Hn8swQEVNLbYGpgIAhR8hQkYtPkIELCGnGDOORKCippb/M1vDzpis3wG92zXH5ZQCbAhIa/S1KoryOLXAGHpd1ERULSGyh2Z1EiJgB29nopJbW+9nz8qq4Ho3G2fj8z742kpuLQ7dzhRmeYTIPOrqJESAisqqEJxR2GBM70ZaEQCgb8cWaK/4/lmcDAMEpRfieVkVzfYkREioxUeIAPnH5H71NTgA/GO//jqEkMZR8BEiQGn5pfWWLHyJSi4PaXmvBFQRIeRdFHyECFBpJVdA16kRyHUIIQ1R8BEiQKrKghk2V1VWFMh1CCENUfARIkA6HVShpNDwYyXP4aCJvBzk5Tj//ZnDafQaHB4XvJc5qK6uFna5hMgkWsdHiAAVlVVh6I5bqH5nnG+JeXcssdCs97ODwY9wMCSrwTXkwaB9xH5kJMVi+vTpsLOzg6mpKeTk6HsqIYJAwUeIAKWnp2PizouoVtcGOJ8fVBwAY/u2h8ssQ2RlZeHkyZPw9vZGaWkpZs6cCVtbW+jp6Qm+cEJkCH2FJEQAeDweDhw4AFNTU9j0U4Nyky8b6+PVVKG//JtF7t27d8ePP/6IpKQkXLp0CQAwceJE9O/fH9u3b0d2drbA6idEllCLj5CvlJubCwcHB5SWlsLLywu9e/f+rL0666goymGGjhI81jnAysoK27dvh6Ji/UkuPB4PoaGh8PHxgb+/P7S1tWFnZwcrKyu0bdtW0G+NEKlELT5CvhDDMPD29sagQYNgbm6O0NBQ9O7dG8CbjaY3jNeFiqI83jOHhY/DebNH54bxuthkOxKxsbFIS0uDubl5g1adnJwczMzM8Pfff+PJkyf48ccfERISgp49e2LChAnw8fHB69evhfWWCZEK1OIj5As8f/4cixYtQnJyMry8vGBgYNDo8xJzi3HodiaC0gvBwZvF6XXqzuMboa2OxcO16m1MzePxsGfPHuzatQtHjhzBpEmTPlhPWVkZzp8/Dx8fH4SFheG7776DnZ0dvvnmmwatRkJkHQUfIZ/pypUrcHJygpWVFbZt2wYVFZWPvuZ5WRX8Y3ORlvcKpZU1UFVWhE7HFpg+6MMnsIeHh2PGjBmYPn06tm/fjiZNmnz0Xs+ePYOfnx+8vb2RmZkJKysr2NraYujQoeB8rPlJiAyg4CPkE5WVlWHNmjUIDAzE0aNHMXLkSJHc98WLF5g7dy4KCgpw6tQpdO/e/ZNf+++//8LX1xfe3t6oqKjAzJkzYWdnh759+wqvYELEHI3xEfIJwsPDMXDgQJSXlyMhIUFkoQcArVu3xoULF2BjYwMjIyNcuHDhk1/bo0cPbNiwASkpKTh37hy4XC6+/fZb6OvrY+fOnXj8+LEQKydEPFGLj5APqK6uxpYtW+Du7o6DBw9i2rRprNYTERGBGTNmYMqUKdixY8cndX2+i8fj4c6dO/D29saZM2fQr18/2NrawsrKCq1btxZC1YSIFwo+Qt4jJSUF9vb26Ny5M44cOYIOHTqwXRKA/7o+8/PzcerUKWhqan78Re9RVVWFq1evwsfHB1evXoWFhQXs7OwwceJENG3aVIBVEyI+qKuTkHfweDzs3r0bw4cPx+LFixEQECA2oQf81/U5c+ZMGBkZ4dy5c198LSUlJVhaWuLUqVPIycnB9OnT4eHhgc6dO2P27Nm4evUquFzBnDhBiLigFh8hb8nKysLcuXPB5XLh6emJHj16sF3SB927dw82NjaYPHkydu7c+UVdn42pm0jj4+ODR48ewdraGnZ2djAyMqKZoUTiUYuPELxZjH7s2DEMHjwY48aNQ3BwsNiHHgAYGRkhLi4OWVlZMDU1xb///iuQ67Zv3x7Lly9HREQEQkND0a5dO8ydOxdaWlrYuHEjUlNTBXIfQthALT4i8549ewZnZ2c8fPgQJ06ckMhNoBmGwb59+7Bt2za4uLhg6tSpQrlHXFwcvL29cfLkSbRv3x62traYOXMmOnfuLPD7ESIsFHxEpgUEBMDZ2Rlz5szBli1boKT0/sXkkiAyMhI2NjaYOHEidu3aJbT3U1tbi+DgYPj4+ODs2bPQ19eHnZ0dpk2bhlatWgnlnoQICgUfkUmlpaVYtWoVgoKC4OnpiWHDhrFdksC8fPkS8+bNQ05ODk6fPi30LtvKykpcuXIF3t7euH79OkaOHAlbW1tMmDDhk3a1IUTUaIyPyJyQkBDo6+tDTk4OCQkJUhV6ANCqVSucPXsWs2fPhrGxMfz9/YV6P2VlZUyZMgX+/v54/PgxJk2aBFdXV3Tq1Alz587F9evXaWYoESvU4iMyo7KyEhs3boS3tzdcXV0xceJEtksSuqioKNjY2OC7777DH3/8IdKu3Ly8PJw8eRI+Pj7Izc2FjY0NbG1tMXjwYJoZSlhFwUdkQnx8POzt7dG7d2+4uLhAXV2d7ZJEpri4GPPnz0dWVhZOnz6Nnj17iryG9PR0/p6hAGBraws7Ozv+MU6EiBJ1dRKpVltbi+3bt+Obb77BmjVr4O/vL1OhBwBqamrw9/fH3LlzYWJiIvSuz8Zoa2tj8+bNyMjIgI+PD0pLS2FhYQFDQ0Ps3bsXT58+FXlNRHZRi49IrYcPH2L27NlQUlLC0aNH0a1bN7ZLYl10dDRsbGwwbtw4/PHHH1BWVmatltraWgQFBcHb2xvnz5+HgYEBbG1tMW3aNLRs2ZK1uoj0oxYfkToMw+Dw4cMwNjaGlZUVbty4QaH3/wwNDRETE4P8/HwMHToUmZmZrNUiLy+P0aNH4+jRo3j69CkWLlyIS5cuQUNDA9OmTcPZs2dRWVnJWn1EelGLj0iVvLw8ODo6Ij8/H15eXujTpw/bJYklhmFw6NAhbNmyBQcOHIC1tTXbJfG9fPkSZ8+ehbe3N+Lj4zFlyhTY2tpi+PDhkJeXZ7s8IgUo+IjU8Pf3x5IlS7BgwQJs3LhRYPtWSrOYmBhYW1tj7Nix2LNnD6tdn43Jzc3FqVOn4O3tjYKCAsyYMQO2trYYNGgQzQwlX4yCj0i84uJiLF26FJGRkfD09ISxsTHbJUmUkpISODk54cGDBzh9+jR69erFdkmNSk1NhY+PD3x8fKCoqAhbW1vY2tpCS0uL7dKIhKExPiLRbt68CT09PbRs2RJxcXEUel+gZcuWOHXqFJycnDB06FCcOnWK7ZIapauri19//RWZmZk4duwYioqKYGpqCiMjI+zbtw/5+flsl0gkBLX4iESqqKjAjz/+iDNnzsDd3R1jx45luySpEBsbC2tra3zzzTfYu3ev2HV9vovL5eLmzZvw9vZGQEAAhgwZAjs7O0yZMgWqqqpsl0fEFLX4iMSJjo7GoEGD8OzZMyQmJlLoCdCgQYMQGxuLFy9ewNjYGBkZGWyX9EEKCgoYO3YsPD098fTpU8yfPx9nz55F165dYW1tjfPnz6OqqortMomYoRYfkRg1NTXYvn07Dhw4gP3792PGjBlslyS1GIaBi4sLfv75Z+zfvx8zZ85ku6TP8vz5c5w5cwbe3t5ITk7G1KlTYWdnB3Nzc8jJ0fd9WUfBRyRCeno67O3t0apVK3h4eND5byISFxcHa2trjBw5En/++adEnraQk5MDX19f+Pj4oKioCDNnzoSdnR309fVpZqiMoq8+RKzxeDwcOHAApqammDt3Lq5evUqhJ0IDBw5ETEwMSkpKYGxsjPT0dLZL+mxdu3bF2rVrER8fj3/++QdNmjTBlClT0LdvX2zdulVgp9YTyUEtPiK2cnNz4eDggNLSUnh5edGGxixiGAaurq7YuHEj9u3bB1tbW7ZL+ioMwyA8PBze3t7w8/ODlpYWbG1tYW1tjXbt2rFdHhEyCj4idhiGga+vL1auXIlly5Zh3bp1UFBQYLssgjenXFhbW2P48OHYt2+fRHZ9vqumpgbXr1+Hj48PLl26BBMTE9ja2mLy5Mlo0aIF2+URIaDgI2Ll+fPnWLx4MZKSkuDl5QUDAwO2SyLvKC0thbOzM1JSUnD69Gno6OiwXZLAvH79GgEBAfD29sadO3cwbtw42NnZYezYsbQTkBShMT4iNq5cuQJ9fX106tQJMTExFHpiSlVVFT4+Pli6dCnMzMz4Z+xJg2bNmmHmzJm4dOkSHj58CAsLC+zcuROdOnXCwoULERISAh6Px3aZ5CtRi4+w7vXr11i9ejUCAwNx9OhRjBw5ku2SyCdKSEiAtbU1zM3NsX//fqno+mxMVlYWTp48CW9vb5SUlPBnhurp6bFdGvkC1OIjrAoPD8eAAQNQXl6OhIQECj0Jo6+vj+joaLx+/RpGRkZIS0tjuySh6N69O3788UckJSXh8uXL4HA4mDBhAvr374/t27cjKyuL7RLJZ6AWH2FFdXU1tmzZAnd3dxw8eBDTpk1juyTyFRiGgZubG9avX4+9e/di1qxZbJckdDweD6GhofDx8YGfnx90dHRgZ2cHKysrtG3blu3yyAdQ8BGRS0lJgb29PTp37owjR46gQ4cObJdEBCQxMRHW1tYYNmwY9u/fj6ZNm7JdkkhUV1fj2rVr8Pb2RmBgIMzMzGBrawtLS0s0a9aM7fLIO6irk4gMj8fDnj17YGFhgcWLFyMgIIBCT8ro6ekhKioKlZWVMDIyQmpqKtsliUSTJk0wYcIE+Pr64smTJ5gxYwZOnDiBzp07w87ODoGBgaipqWG7TPL/qMVHRCI7Oxtz5swBl8uFp6cnevTowXZJRIgYhoGHhwd+/PFH7N69G7Nnz2a7JFY8e/YMfn5+8Pb2xoMHD2BlZQU7OzuYmJjQnqEsouAjQsUwDI4fP441a9Zg9erVWL16NeTl5dkui4hIUlISrK2tYWJiggMHDshM12dj/v33X/j6+sLb2xvl5eX8g3T79evHdmkyh4KPCM2zZ8/g7OyMhw8f4sSJEzT1W0aVlZVh0aJFiIuLw+nTp9GnTx+2S2IVwzBISEiAj48PfH190bp1a9ja2mLmzJnQ0NBguzyZQG1tIhQBAQHQ19dH7969ERUVRaEnw5o3bw5PT0/873//g4WFBY4fP852SazicDgYMGAAdu7ciezsbOzfvx8PHz7EwIEDYWFhAVdXV7x48YLtMqUatfiIQJWWlmLVqlUICgrC8ePHYWZmxnZJRIwkJyfDysoKxsbGOHDgAM14fEtVVRWuXr0KHx8fXL16FRYWFrCzs8PEiRNluotYGKjFRwQmJCQEAwYMgJycHBISEij0SAP9+vVDVFQUeDwehgwZgpSUFLZLEhtKSkqwtLTEqVOnkJOTg2nTpsHDwwOdOnXC7NmzcfXqVXC5XLbLlArU4iNfrbKyEhs3boS3tzdcXV0xceJEtksiEuDYsWNYs2YNdu3ahblz57JdjtjKz8/H6dOn4e3tjaysLFhbW8POzg5GRkZ0kO4XouAjXyUhIQGzZs1Cr1694OrqCnV1dbZLIhIkJSUFVlZWGDx4MA4dOkRdnx+RmZnJnxlaXV0NW1tb2NnZQVdXl+3SJAp1dZIvUltbi99//x2jR4/GmjVrcObMGQo98tn69u2LqKgocDgcDB48GMnJyWyXJNa0tLSwceNGpKamwt/fHxUVFRg9ejQGDhyIP/74A7m5uWyXKBGoxUc+28OHDzF79mwoKSnh6NGj6NatG9slESlQ1/W5Y8cOODg4UDfeJ6qtrUVwcDB8fHxw9uxZ6Ovrw87ODtOmTUOrVq3YLk8sUfCRT8YwDI4cOYINGzZgw4YNWL58Oe0+QQQqJSUF1tbWMDAwwKFDh9C8eXO2S5IolZWVuHLlCry9vXH9+nWMHDkStra2mDBhgtQeGfUlKPjIJ8nLy4OjoyPy8/Ph5eUl84uQifC8fv0ay5YtQ3h4OPz8/Ghnky9UUlKCs2fPwtvbGzExMbC0tISdnR1GjBgBBQWFr75+UVkV/GNykZZfitJKLlSVFaDTQRVWBl3QprmSAN6B8FDwkY/y9/fH0qVL4eTkhI0bN6JJkyZsl0RkwPHjx7F69Wr8/vvvmDdvHnV9foW8vDycPHkSPj4+yM3NhY2NDWxtbTF48ODP/u+akFOMg7czEZxRCACo4v53Ir2yghwYAMO11bHYQgv6XdUE+C4Eh4KPvFdxcTGWLVuGe/fuwdPTE8bGxmyXRGTM/fv3YW1tjYEDB+Lvv/+mrk8BSE9P588MBcDfM1RbW/ujrz0RkYWtgWmo5NbiQ8nB4QDKCvLYMF4Hs4y7C6hywaEBGtKomzdvQk9PD6qqqoiLi6PQI6zo06cPIiMj0aRJExgaGiIpKYntkiSetrY2Nm/ejIyMDPj4+KCkpATDhw+HoaEh9uzZg6dPnzb6ujehl4qKmg+HHgAwDFBRU4utgak4EZEl+DfxlajFR+qpqKjAunXr4O/vD3d3d4wdO5btkggBAHh5eeF///sftm/fjvnz51PXpwBxuVwEBQXBx8cH58+fx6BBg/gzQ1u2bImEnGLMOBKBipraRl/frbUKzjsPxrXUQvxwvv4ZjCqK8ji1wBh6XdRE8E4+DQUf4YuOjoa9vT309fVx6NAhtG7dmu2SCKknNTUV1tbW0NPTg4uLC1q0aMF2SVKnoqICly9fhre3N27duoXRo0ejasgcpBTL431hccRWH8qKcnhaUtkg+DgcYGyf9nCZZSj84j8RdXUS1NTU4JdffsH48eOxadMmnDx5kkKPiCVdXV3cu3cPTZs2haGhIRITE9kuSeqoqKhg+vTpOHfuHLKysmD+zXdIecG8N/TG9W2HV1VcRDx62ejjDAMEpRfieVmV8Ir+TBR8Mi49PR2mpqYIDQ1FXFwcZsyYwXZJhHxQ06ZNceTIEWzcuBGjRo3C4cOHQR1XwtGqVSso6Vq8dyZ3sybyWGahiR3XMj94HQ4A/1jx2VXm6xdzEInE4/Fw6NAhbN68Gb/88gsWLVpEYyZEosyaNQuGhoawtrbG7du34erq+t6uT0lec8a2tPzSeksW3rZ8uCbOxOeh4NWHW3OVXB7S8l4Jo7wvQsEng3JzczFv3jyUlJQgLCwMvXv3ZrskQr6Ijo4O7t27hxUrVsDAwAB+fn7Q19fnP/7hNWf52HsjQ+zXnLGttLLxo5B02jeHSY/WmHY46hOvUyPIsr4KdXXKEIZh4OPjg0GDBsHMzAyhoaEUekTiqaio4PDhw9i8eTNGjx4NV1dXMAyDExFZmHEkAtdTC1DF5TVotVT+/8+u3S/AjCMRYjntXhyoKjfePhrcTQ2dWirj5goThKwaCgeTrvhGRx3+jo1PYlFVVhRmmZ+FWnwy4sWLF1i0aBGSkpJw5coVGBgYsF0SIQJla2sLAwMDWFtb42R0LvI6DEXle7ro3vb2mjMAYrngmi0FBQXIS40GuG0BhfrjfH6xT3El5Rn/3x1MuqKTmjJ+CcxocB1lBTnodBSfGbjU4pMBV69ehZ6eHjp16oSYmBgKPSK1tLW1ceTMNWS3MawXetE/mNX7J2nDcGwY26veaytqeNgamIbE3GIRVy1eeDwebt68CWtra+jo6EDpSRwUG5ncUsnloeh1Nf+f8upaVHN5eFnesEuTATB9UBcRVP9pqMUnxV6/fo3Vq1cjMDAQnp6eGDlyJNslESJ0buE5YOQU8Pb8e8Mdd/h/bqooj5D/DcXV1GcNXlvJrcWh25liteZMVAoLC3Hs2DEcPnwYKioqcHZ2xpEjR9CyZUss8IrG9dSCD+7YcjAkq9GfczjACG11sZpERC0+KRUeHo4BAwagvLwcCQkJFHpEJhSVVSE4o/CDv6C/0VXH89c1iHlc0uAxcVxzJkwMwyA4OBi2trbo1asXUlJS4OnpiYSEBCxZsgQtW7YEACwZrgVlBfkvuoeygjwWD9cSZNlfjYJPylRXV+Onn37ClClT8Pvvv+P48eNQU1NjuyxCRMI/5uNrxSz1OiAgMf+9j4vbmjNhePHiBfbu3Ys+ffpg0aJFMDIywqNHj3Ds2DGYmJg0WNqk31UNG8brQEXx8yJDRVEOG8briNV2ZQB1dUqVlJQU2Nvbo1OnToiPj0eHDh3YLokQkfrQmjMA6NRSCYO7qWHjpbT3Pkfc1pwJCsMwCAsLg6urKwICAjBhwgQcPnwYw4YN+6Q1vHWTfqThdAYKPinA4/Hw559/Yvv27di2bRscHR1pMTqRSe9bc1ZnYv8OiM0pwZPiyo9cR3zWnH2t4uJieHl54fDhw6iursaCBQuwZ88etG3b9rOvNcu4O/S6qOHQ7Uz8k/QE8vLy4DL//a6pO49vhLY6Fg/XEruWXh0KPgmXnZ2NOXPmgMvl4t69e+jRowfbJRHCmvetOatjqdcBbqHZn3Ad8Vlz9iUYhkFkZCRcXV1x9uxZfPvtt9i/fz+GDx/+1V+K9bqowWWWIbrrOGDOb4fxolYFpZU1UFVWhE7HFpg+SPx3w6Hgk1AMw+D48eNYs2YNVq9ejdWrV0Ne/ssGnwmRFjodVKGkkN9od+eALqpo10IJV1MLP3gNcVtz9jlKS0vh7e0NV1dXvHr1CgsWLEBGRgbatWsn0Ps8e/YMxfk52DDVCHJykjdVhIJPAhUWFsLZ2RmZmZn8A2MJIcB0gy7Ye6PhAmoAmKzXATfSClFe3fiZcnXEbc3Zp4iJiYGrqyv8/PwwatQo7Nq1C6NGjRJaKEVFRWHw4MESGXoABZ/ECQgIwMKFC2Fvbw9fX18oKYl3lwIhotS2uRJ0VHmIL+KB884v5c2N7CjyLnFcc/Y+ZWVlOHnyJFxcXFBUVAQnJyfcv38fHTt2FPq97927hyFDhgj9PsJCwSchSktLsWrVKgQFBeHUqVMwMzNjuyRCxEpZWRm+//57JESlQmncD6j++G5lDYjjmrN3JSQkwNXVFSdPnoS5uTl+/fVXjBkzRqRDHZGRkVi0aJHI7idoktlOlTF37tzBgAEDICcnh4SEBAo9Qt5x9+5d6Ovro6amBom3L+HniX2lZs0ZAJSXl+PYsWMwNjbGhAkT0L59eyQmJuL8+fMYN26cSEOvbuIMtfiIUFRVVWHjxo04ceIEXF1dMXHiRLZLIkSsVFVV4eeff4anpydcXFxgaWkJAJhlrArg09acgeFBpYmiWK45S0lJgaurK7y9vWFsbIwNGzZg3LhxUFBg71d3ZmYmmjdvLpIuVWGh4BNTCQkJmDVrFnr16oWEhASoq6uzXRIhYiUhIQH29vbo2bMnEhISGsxcfHvNWVB6IThAvY2rlRXkwGMYvH4Qg6Pr7TFCv7to38B7VFZWwt/fHy4uLvj3338xf/58xMbGolu3bmyXBgAS39oDAA7DfPC7EBGx2tpa7Nq1C7t378bu3bthb29Pi9EJecvbn5E//vgDs2fP/uhn5HlZFfxjc5GW96rBmrNfNqyFvLw89uzZI6J30Li0tDQcPnwYXl5eGDRoEBYuXIgJEyZAUVG81hQuX74cXbt2xZo1a9gu5YtR8ImRhw8fYvbs2VBSUsLRo0fF5hseIeIiMzMTc+bMEehnJC8vD3379kVKSorIu++qqqpw7tw5uLi4IC0tDQ4ODnBychLrjSiMjY2xY8cOWFhYsF3KF6PJLWKAYRgcPnwYxsbGsLKywo0bNyj0CHkLwzBwdXWFiYkJrK2tBfoZ6dixI2bPno0dO3YI5HqfIjMzE2vXroWGhgaOHDmCJUuW4PHjx9i+fbtYh151dTWSkpIk/kxPGuNjWX5+PhwdHZGXl4fg4GD06dOH7ZIIEStPnz7F/PnzUVhYiJCQEOjq6gr8Hj/88AP69u2LH374QWitvpqaGly4cAEuLi5ITEzEnDlzcPfuXfTq1evjLxYTCQkJ6NmzJ5o3b852KV+FWnwsOnPmDAYMGICBAwciPDycQo+Qd5w6dQoDBw6EkZERwsPDhRJ6wJtW39y5c/H7778L/NqPHj3C+vXroaGhgb/++gvz589HTk4Odu3aJVGhB0jHxBaAWnysKC4uxvLlyxEREYHz58/D2NiY7ZIIESsvXrzA0qVLERsbi0uXLmHw4MFCv+fatWvRp08frF27Fp07d/6qa3G5XFy6dAkuLi6Ijo6Gvb09bt26JbTgFpXIyEgMGzaM7TK+GrX4ROzmzZvQ19dHixYtEBcXR6FHyDv++ecf6OnpQV1dHXFxcSIJPQDo0KEDHBwcvqrV9/jxY/z888/o1q0b/vjjD9jZ2SEnJwd79+6V+NADJH+rsjo0q1NEKioqsG7dOvj7+8Pd3R1jx45luyRCxMrr16+xZs0aXLp0CUePHsWoUaNEXkNBQQF0dXWRlJT0ya2+2tpaXLlyBa6urggLC4OtrS2cnZ3Rr18/IVcrWsXFxejSpQuKi4tZXUAvCNTiE4Ho6GgMGjQI+fn5SExMpNAj5B3h4eEYMGAAXr9+jcTERFZCDwDat2+PefPmYfv27R997pMnT/DLL79AU1MTv/32G6ZOnYqcnBz89ddfUhd6wH+/xyQ99AAADBGampoaZsuWLUy7du0YX19ftsshROxUVVUx69evZ9q3b8+cOXOG7XIYhmGYgoICplWrVszjx48bPFZbW8tcuXKFmTx5MtOqVStm4cKFTFxcnOiLZMFvv/3GfP/992yXIRBSEN3iKT09HbNnz4aamhpiY2O/erCcEGmTlJQEe3t7aGhoID4+Hh06dGC7JABAu3bt4OjoiN9//x0HDx4E8GbZkYeHB44cOYI2bdrA2dkZXl5eEj+t/3NERkbCzs6O7TIEg+3klTa1tbXMX3/9xbRp04Y5ePAgw+Px2C6JELHC5XKZnTt3Mm3btmXc3d3F8jNSUFDAqKmpMd7e3sz06dMZNTU1xtHRkYmKimK7NFbweDymffv2TFZWFtulCAS1+AToyZMncHBwQElJCcLCwtC7d2+2SyJErDx69Ahz5swBh8NBZGQkNDU12S6pgcLCQhw7dgzAm30pf/31V7i7u0NVVZXdwliUk5MDhmGgoaHBdikCQZNbBMTX1xcDBw6EmZkZQkNDKfQIeQvDMHBzc8OQIUNgaWmJoKAgsQo9hmFw+/ZtzJw5E7169UJqaip8fHxQW1uL7777TqZDD/hv4bq0bJhPLb6v9OLFCyxevBiJiYm4cuWKxO9hR4ig5efnw8nJCU+ePEFQUJBYzXh8/vw5jh8/jsOHD0NBQQHOzs74+++/oaamBgBwdnbGtm3b4OLiwm6hLIuMjISRkRHbZQgMtfi+wtWrV6Gnp4eOHTsiJiaGQo+Qd9RtyzdgwABERESIRegxDIO7d+/yz/KLi4uDm5sbkpKSsGzZMn7oAcDq1avh5+eH7Oxs9goWA9KycL0OLWD/AnULbS9fvoyjR49i5MiRbJdEiFgpLi7GsmXLcO/ePXh6eorFDkUvX76El5cXXF1dUVtbC2dnZ8yePRtt2rT54OvWr1+P58+fw9XVVUSVihcul4tWrVrh8ePHaNWqFdvlCAS1+D5TREQEf6FtQkIChR4h77hx4wb09PTQsmVL1rflYxgGERERcHBwgKamJsLDw3Hw4EGkpqZi1apVHw09APj+++/h7++PrKws4Rcshu7fv49OnTpJTegBMjrGV1RWBf+YXKTll6K0kgtVZQXodFCFlUEXtGmu1Ohrqqur8csvv8DNzQ0HDx7EtGnTRFw1IeKtvLwcP/74I86dOwd3d3eMGTOGtVpKS0tx4sQJuLq6ory8HAsWLMDOnTuhrq7+2ddq06YNFi5ciK1bt+LIkSNCqFa8ScuJDG+TqeBLyCnGwduZCM4oBABUcXn8x5QV8rH3RgaGa6tjsYUW9Luq8R9LSUmBvb09OnXqJFYLbQkRF5GRkbC3t4ehoSESExNZax1ER0fD1dUV/v7+GD16NHbv3o2RI0dCTu7rOre+//579OrVC+vXrxer2aiiII3BJzNdnScisjDjSASupxagisurF3oAUPn/P7t2vwAzjkTgREQWeDwe9uzZg+HDh2PRokW4ePEihR4hb6mpqcHPP/+MiRMn4tdff4W3t7fIQ6+srAyHDx+GgYEBrKys0KNHD6SmpsLPzw+jR4/+6tADgNatW2Px4sXYunWrACqWLPfu3ZOqGZ2AjExuORGRha2Bqaio4X38yf9PSYGD5hn/QOVJDDw9PdGjRw8hVkiI5Ll//z7s7e3RoUMHuLm5Ce3k8veJj4+Hq6srTp06BQsLCzg7O2PMmDECCbrGvHjxAr1790ZkZKTM/D54/fo11NXV8fLlSygpNT4MJImkvqszIacYWwPTGoTeMfsB0O+iilrem9wveFWN7w7d4z9exWVQ22M03HZtQg+N1iKtmRBxxuPxsG/fPmzbtg3btm2Do6OjyBY2v379GqdOnYKrqyvy8vLg5OT0WUcIfY23W33u7u5Cv584iI2NRf/+/aUq9AAZCL6DtzNRya1t9LHfrjzAmfi89762liMH15B/4TKLgo8QAMjOzsbcuXNRU1ODiIgI9OzZUyT3TU5OhqurK3x8fDB06FBs3LgR48aNg7y8vEjuX2fVqlX8sT5RvXc2Sdv6vTpSPcZXVFaF4IxCfGlnLsMAQemFeF5WJdjCCJEwDMPg2LFjMDQ0xLhx4xAcHCz0X/wVFRXw9PSEqakpxo4di9atWyMuLg4XL17EhAkTRB56ANCqVSssWbIEv/32m8jvzQZpnNgCSPkYn0vwQ+y9kdFgIgvwpqtTS70ZOBzg0fMK7Av6F1HZxQ2ep6wgh1Xf9IazufR/uyOkMc+ePcOCBQvw6NEjeHl5QU9PT6j3S0tLg6urK7y8vDB48GA4OztjwoQJYnMAanFxMbS0tBAREQEtLS22yxGq7t2749q1a1K397BUt/jS8ksbDT0A2HPzX4w5EIHhf4bBL/YpDtn0R9dWyg2eV8nlIS3vlbBLJUQsnT9/Hvr6+tDV1UVkZKTQQq+qqgo+Pj6wsLDAiBEj0LRpU0RFReHKlSuYPHmy2IQeAKipqWHZsmVS3+orKChASUmJVIa7+PxtEoLSSu57H0t8Wsr/84XEfIzv2w7mWm3gHfWkkevUCKU+QsRVSUkJVqxYgbt378Lf3x+mpqZCuc+DBw9w+PBhHD9+HPr6+li2bBksLS2hqKgolPsJyooVK6ClpYUHDx6gV69ebJcjFJGRkRg8eLDQZsmySfre0VtUlT8v1983L01VWbw/hIQIUlBQEPT19aGsrIz4+HiBh151dTVOnz6NUaNGYdiwYZCTk0NYWBiuX7+O6dOni33oAW9afcuXL5fqVp+0ncjwNqlu8el0UIWSQn6D7s4WSgrQ66yKqOxi1PIYjOvbDgYaatj2z4MG11BWkINOxxaiKpkQ1lRUVGD9+vU4ffo03NzcMG7cOIFe/99//8WRI0dw9OhR6OrqwtnZGVOmTJHYqfJ1rb6MjAypGwMD3szoXLZsGdtlCIVUB990gy7YeyOjwc8V5DlYPkITPdo0RS3D4FFROZadTkL2i4oGz2UATB/URQTVEsKe6Oho2NvbQ09PD4mJiZ+0efOnqKmpwcWLF+Hq6orY2FjMnj0bwcHB0NbWFsj12dSyZUv+Ce1eXl5slyNQPB4PUVFRUjmjE5Dy4GvbXAkWvdVxPbWg3pKGl+U1sHGP+ejrORxghLb6ezeuJkTS1dTUYPv27Thw4AD279+PGTNmCOS62dnZcHNzg4eHB3r06AFnZ2dcuHABysoNJ5BJshUrVqBnz55IT0+XijCvk5mZiZYtW6J9+/ZslyIUUj3GBwBLhmtBWeHL1vsoK8hj8XDpm9FECACkp6fD1NQUoaGhiIuL++rQ43K5uHjxIr777jsYGBigtLQU165dw507dzBr1iypCz0AUFVVxcqVK/Hrr7+yXYpASevC9TpSH3z6XdWwYbwOVBQ/7602kQM2jNeBXhc14RRGCEt4PB7++usvDBs2DA4ODrh69epXbfmVm5uLLVu2QFNTE9u2bYO1tTUeP36Mffv2oW/fvgKsXDwtW7YM165dQ1paGtulCIy0LlyvI/XBBwCzjLtjw3hdqCjK42NbCnI4b0Kv7I4njNrQMgYiXXJycjBmzBj4+PggLCwMixYt+qJ9Nmtra3HlyhVYWlpCT08Pz549w+XLlxEeHo45c+agadOmQqhePEljq08aT2R4m1Tv3PKuxNxiHLqdiVtphaisrICc4n9jd8oKcmDwZkxv8XAthF8+hX379iE8PBwtW7Zkr2hCBIBhGJw4cQLff/89Vq5cibVr137RovC8vDx4eHjgyJEjUFdXx8KFCzFjxgw0a9ZMCFVLjlevXqFnz54IDg6Grq4u2+V8laqqKrRq1QqFhYVS+/9VpoKvzpVbd/D9QX+MtXZAaWUNVJUVodOxBaYPqn8C+5IlS5CdnY0LFy6wsi8gIYJQWFiIhQsXIj09HV5eXhg4cOBnvZ7H4+HmzZtwcXHBrVu3YG1tDWdnZwwaNEhIFUum7du3IzExEb6+vmyX8lUiIyPh5OSEhIQEtksRGqme1fk+D5LjYK5ehb02Az74vD///BNjxozBhg0b8Pvvv4umOEIE6OLFi3B2doadnR28vb0/a4LJs2fPcPToURw+fBiqqqpwdnbG0aNHoaqqKsSKJdfSpUuhpaWFlJQUiR7blPZuTkBGxvjeFRMTAwMDg48+T1FREX5+fjh9+jS8vb1FUBkhglFaWgpHR0esWLECJ0+exK5duz4p9BiGQVBQEGxsbKCtrY2MjAz4+voiNjYWCxcupND7gBYtWuB///ufxI/1SfvEFoCC76Patm2LgIAArFy5ElFRUUKujJCvFxISAn19fXA4HCQkJMDc3PyjrykqKsLu3buho6OD5cuXw8zMDI8ePYK7uzuGDBkisoNmJd2SJUsQFBSElJQUtkv5YtK8VVkdmRvje/36NdTV1VFcXIwmTZp88usuXLiApUuX4t69e+jUqZMQKyTky1RWVuKnn36Cj48PDh8+jAkTJnzw+QzD4O7du3BxcUFgYCAmTZoEZ2dnmJiYUNB9hZ07dyI6OhqnT59mu5TP9vLlS2hoaKC4uFiq5zXI3BhfQkIC+vbt+1mhBwCWlpZITk7GlClTEBwcLJWLcYnkiouLg729PXR0dJCYmIi2bdu+97kvX76Ep6cnXF1dwTAMnJ2d8ddff6F169YirFh6LVmyBD169EBycjL69evHdjmfJSoqCoMGDZLq0ANksKszOjr6k7s537V+/XpoampiwYIFkLGGMhFTXC4X27Ztw9ixY/Hjjz/Cz8+v0dBjGIa/xq5Hjx6IjIyEi4sL7t+/j5UrV1LoCVCzZs2wevVqbNmyhe1SPpssdHMCMhh8nzO+9y4OhwMPDw8kJydj9+7dAq6MkM/z4MEDmJmZ4datW4iJicGsWbMadFGWlJTg4MGD0NfXx5w5c9C/f388ePAA3t7eMDc3py5NIVm8eDHu3LmDxMREtkv5LNK+VVkdmRvj69evHzw9Pb9qDVJOTg6MjIzg5uaG8ePHC7A6ImuKyqrgH5OLtPxSlFZyoaqsAJ0OqrAy6PLezdEZhsHff/+NTZs2YdOmTVi8eHG9w0IZhkF0dDRcXFxw9uxZjBkzBs7OzhgxYgQFnQjt3r0b4eHh8Pf3Z7uUT8IwDDp06ICoqChoaGiwXY5QyVTwfenElsaEhYVh8uTJCAkJgY6OjoAqJLIiIacYB29nIjijEADqnRlZt4vQcG11LLbQgn5XNf5jT548wbx58/Dy5Ut4eXnVOxHg1atX8PHxgaurK4qLi7FgwQI4ODhI7Q774u7169fQ0tLC1atXoa+vz3Y5H5WdnQ1jY2M8ffpU6r8gyVRXZ0JCAvr06fPVoQcAQ4cOxe+//45Jkybh5cuXAqiOyIoTEVmYcSQC11MLUMXlNTgoufL/f3btfgFmHInAiYgsMAwDX19fDBw4EKampggLC+OHXlxcHBYuXIhu3brh2rVr+P3335GZmYkff/yRQo9FzZo1w5o1ayRmrK+um1PaQw+QsVmdXzO+15h58+YhKSkJNjY2CAwM/KK9D4lsORGRha2Bqaio4X30uQwDVNTU4rfLqXBzc8ezsDMIDAyEoaEhXr9+jePHj8PV1RUFBQVwcnJCcnIyLbURMwsXLsQff/yB+Ph4DBgwgO1yPkgWFq7XkakWn6CDDwB27doFAFi7dq1Ar0ukT0JOMbYGpjUaeuP6tsPFRUMQ/YM5ri4xhkHX/zZGr+TykNN2MI5fDIKSkhKWLl0KDQ0NBAQEYPPmzfj333/x008/UeiJoaZNm2Lt2rUS0eqTlRmdgIyN8fXv3x/Hjh0TePi9fPkSRkZGWLduHRwcHAR6bSI9FnhF43pqAd79xJlotsKvE3Twv7MpSHpSCvUWb7rin72q5j+HAwZKhekou7oXjo6OmD9/Prp27SrK8skXqqioQM+ePXH58uXP3iBcVLhcLtTU1JCbmws1NTW2yxE6membKy8vx8OHD4WyoLRVq1a4cOECLCwsoK2tjaFDhwr8HkSyFZVVITijsEHoAcBSC00cupOFxCelAOoHXh0GHHDbaSMmJQPtW8rOWXfSQEVFBT/88AO2bNmC8+fPs11Oo1JSUtClSxeZCD1Ahro6ExISoKurCyWlxqeIfy1dXV0cO3YMVlZWyMnJEco9iOTyj8lt9OdyHKBfpxZo3VQRV5cY4dYKE2z4theUFBp+NBXk5XE+IU/YpRIhWLBgAaKiohAbG8t2KY2SpW5OQIaCTxjje+8aP348Vq5cicmTJ6O8vFyo9yKSJS2/tMHsTQBo06wJFOXlMEZXHbOOx2Hq4WjodmiBhWbdGjy3kstDWt4rUZRLBKyu1bd582a2S2mUrCxcr0PBJ2CrV69Gnz59MG/ePNrWjPCVVnIb/XldGHpHPUFRWTWKK2pwPCIH5lpt3nOdGqHVSIRrwYIFiI2NRUxMDNulNEAtPiklquDjcDg4cuQIHj16hO3btwv9fkQyqCo3PpxeWslFXkklGPz3JentPze8jqLAayOioaysjB9//FHsWn1lZWV4+PAh9PT02C5FZGQi+MrLy5GZmYn+/fuL5H7Kyso4d+4cDh06hICAAJHck4g3TbUmUEDja/fOJeTDbnAXtG6qCFVlBcwx6orbD543eJ6yghx0OrYQdqlEiBwdHREXFydWZ3vGxMSgf//+AtnYQ1LIRPAJe2JLYzp16oSzZ8/C0dFRog+lJF+OYRiEhYVh3rx52DJ3PGp5jQefy50sJD99hcAlRri0aAhS88vgeie74fUATB/URchVE2FSVlbGunXrxGpdn6x1cwIyEnyi6uZ815AhQ7Bnzx5MmjQJz583/AZPpFNRURH27t2Lfv36wcHBAbq6ukhLiMI3/Tqjsd2guDwGv17JgPGuuzDfG4Zt/zxAdW39kORwgBHa6u/duJpIDkdHRyQkJCAyMpLtUgDI3sQWgIJP6GbNmoXp06fDysoKNTU0MUFa8Xg83LhxAzNmzICWlhbi4uLg4uKCtLQ0rFmzBu3atcOS4VpQVviyAz6VFeSxeLiWgKsmbFBSUsK6devEZqxPlrYqq0PBJwLbtm2DiooK/ve//7FWAxGOJ0+eYOvWrdDS0sLq1athZmaGrKwseHp6wszMrN6Gv/pd1bBhvA5UFD/vY6eiKIcN43Wg10VNwNUTtsyfPx/Jycm4d+8eq3Xk5eWhrKwMWlqy9aVK6oOvoqJCpBNbGiMvLw8fHx/cuHEDhw8fZq0OIhhcLhcBAQGYNGkS+vfvj5ycHPj5+SEuLg5Lliz54O4Xs4y7Y8N4Xagoyjfa7fk2DgdQUZTHhvG6mGXcXaDvgbBLSUkJ69evZ73VV9fak4UTGd4m9VuWJSQkQEdHR6QTWxrTsmVLBAQEYNiwYdDR0YG5uTmr9ZDP9/DhQ3h4eODYsWPo3r07HB0d4evri2bNmn3WdWYZd4deFzUcup2JoPRCcPBmcXqduvP4RmirY/FwLWrpSSkHBwds374d4eHhMDExYaUGWezmBGQg+Nju5nxbr169cOLECdjY2CAiIgLdujXcnYOIl8rKSpw/fx5ubm5ISEiAvb09rl+/jj59+nzVdfW6qMFlliGel1XBPzYXaXmvUFpZA1VlReh0bIHpg95/AjuRDnWtvi1btuDq1aus1BAZGYmVK1eycm82Sf3pDPPmzcOQIUOwcOFCtkvh27dvHzw8PBAaGormzZuzXQ5pREpKCtzc3HDixAkMGDAATk5OsLS0ZL3ngEiX6upq9OrVCydPnhR5q4/H46F169bIyMhAu3btRHpvtkn9GJ84tfjqLF++HIaGhpg7dy5471nbRUSvrKwMHh4eMDExwZgxY9CsWTNERkbi+vXrsLa2ptAjAtekSRNs2LABmzZtEvm9MzIy0KpVK5kLPUDKg6+iogIPHjxgdWJLYzgcDg4dOoS8vDz8+uuvbJcj0xiGQVRUFJydnaGhoYELFy5g/fr1yM7Oxm+//QZNTU22SyRSbu7cuXjw4AFCQ0NFel9ZXLheR6rH+BITE6GtrQ1lZWW2S2lASUkJZ8+exZAhQ9CvXz9MmzaN7ZJkysuXL+Ht7Q03Nze8evWKP72cTjEnolbX6tu8eTOuX78usvvK4sL1OlLd4hPHbs63tW/fHufOncOiRYuQkJDAdjlSj2EYBAcHw97eHpqamggNDcWePXvw4MEDrF+/nkKPsGbOnDnIzMzE3bt3RXZPWZ3RCVDwsW7QoEH466+/YGlpiWfPnrFdjlQqKCjAzp07oa2tjSVLlsDQ0BAPHz6Er68vRo4cCTk5qf4YEAmgqKiIn376SWRjfZWVlUhJScGgQYNEcj9xI9Wf+JiYGBgaGrJdxkfZ2Njwtzarrq5muxypUFtbiytXrmDq1KnQ0dFBRkYGPD09kZSUhBUrVqBNm8bPuyOELbNnz8ajR48QEhIi9HvFx8dDW1sbTZs2Ffq9xJHULmeoqKhAmzZt8OLFC7Ec43sXj8fD1KlT0a5dO7i6usrcTgqCkp2djaNHj8LDwwMdOnSAk5MTbGxsoKqqynZphHyUh4cHTpw4gVu3bgn1Pvv378f9+/fh4uIi1PuIK6lt8YnzxJbGyMnJwcvLC2FhYTh06BDb5UiU6upqnDlzBt9++y0GDRqE58+f4+LFi4iMjISTkxOFHpEY9vb2yM7ORnBwsFDvI8sTWwApntUpCeN772rRogUCAgIwdOhQ6OrqYuTIkWyXJNbS09Ph7u4OT09P6OjowMnJCefOnYOKigrbpRHyRRQVFbFx40Zs3rwZQUFBQrtPZGQk1q1bJ7TrizupbfFJYvABQI8ePeDr64uZM2fi4cOHbJcjdsrLy+Hl5QVzc3NYWFiAw+EgJCQEt2/fhp2dHYUekXizZs1CTk4Obt++LZTrv3jxAgUFBdDV1RXK9SUBBZ8YGjFiBDZt2oRJkyahtLSU7XLEQnx8PJYuXYquXbvC19cXq1atQk5ODnbs2IHevXuzXR4hAqOgoICNGzdi06ZNEMYUjMjISBgYGEBe/svOhpQGUhl8lZWVyMjIgJ6eHtulfLFFixbBzMwMs2bNktltzUpLS+Hq6gpDQ0NYWlqiXbt2iI+PR2BgIKZMmQJFRUW2SyREKOzs7JCXlyeUVp8sr9+rI5XBl5iYiN69e0vMxJbGcDgc7N+/HyUlJdi4cSPb5YgMwzAICwuDg4MDNDQ0cP36dWzduhX//vsvfv75Z3Tt2pXtEgkROmG2+mR5q7I6Uhl8ktzN+bYmTZrA398fPj4+8PX1ZbscoSoqKsKePXvQt29fODg4oE+fPsjIyIC/vz/Gjh0r090yRDbNnDkT+fn5Al3awDCMzM/oBCj4xJ66ujouXLiA5cuXIyYmhu1yBIrH4+HGjRuwsbGBlpYW4uPj4erqirS0NKxZs0Ymd40npI6CggJ+/vlnbN68WWCtvqysLCgqKqJz584CuZ6kouCTAHp6enB1dcWUKVOQn5/Pdjlf7cmTJ9i6dSu0tLSwZs0aWFhYICsrC56enjAzM6PF+4T8v5kzZ+LZs2e4efOmQK5X180p658xqQu+yspKpKenS/TElsZMnToVjo6OmDJlCqqqqtgu57NxuVwEBARg4sSJ6N+/P3Jzc+Hn54fY2FgsXrwYampqbJdIiNiRl5fHzz//LLCxPurmfEPqgi8pKQm9evWSyvVcP/30E7p06YKFCxcKZZqzMDx8+BDr16+HhoYGdu7ciWnTpiEnJwd///03DAwMZP6bJyEfM2PGDLx48QI3btz46mvRjM43pC74pK2b821ycnI4duwY4uLi8Oeff7JdzntVVlbi5MmTGDVqFIyNjVFZWYkbN27g7t27mDt3Lpo1a8Z2iYRIDEG1+mpqahAfHy8RG/cLm1QGnzT/j23WrBkuXLiAnTt34p9//mG7nHqSk5OxcuVKdO3aFe7u7nB2dkZubi727NmDPn36sF0eIRLL2toaxcXFuHbt2hdfIzk5GRoaGmjZsqUAK5NMUhd80dHRUtviq9OtWzf4+flh9uzZyMjIYLWWsrIyuLu7w8TEBGPHjkWLFi0QGRmJ69evw9raGkpKSqzWR4g0qGv1fc0MT+rm/I9UBZ+0TmxpzLBhw7B161ZMmjQJJSUlIr03wzCIiorCggULoKGhgYsXL2LDhg3Izs7Gr7/+Ck1NTZHWQ4gssLKyQmlp6Rf39NDC9f9IVfBJ88SWxjg6OmLMmDGYOXMmamtrhX6/ly9f4sCBAxgwYABmzJgBTU1NJCcn4/z585gwYQIUFKT2sA9CWPe1Y300o/M/UhV80jyx5X327NmD6upqoR0xwjAMgoODMWvWLGhqaiI0NBR79+7FgwcPsG7dOnTq1Eko9yWENGRlZYXXr1/j6tWrn/W6V69e4dGjRzLRG/YpKPgknIKCAk6dOoWzZ8/Cy8tLYNctKCjAjh07oK2tjSVLlmDw4MF4+PAhfH19MXLkSMjJSdVfHUIkgpycHDZt2vTZrb7o6Gjo6+vTxu7/T6p+e8li8AFAmzZtcOHCBXz//fe4d+/eF1+ntrYWgYGBmDp1KnR0dPDgwQN4enoiKSkJK1asQJs2bQRYNSHkS0ybNg0VFRUIDAz85NfQxJb6OIykrIT+iKqqKrRq1QrPnz+XmTG+d128eBGLFi3CvXv3PmsvvuzsbHh4eMDDwwMdO3aEk5MTbGxsoKqqKsRqCSFfyt/fHzt27EBkZOQnbQIxbdo0TJ8+HTNnzhRBdeJPalp8SUlJ0NLSktnQA4CJEydi6dKlmDJlCioqKj743Orqapw5cwbffvstDAwM8PLlS1y6dAmRkZFwcnKi0CNEjE2dOhVVVVW4fPnyJz2fJrbUJzXBJ6vdnO/64YcfoKWlBScnp0bHANLT07FmzRp07doVBw4cgL29PXJycrB//37o6+uzUDEh5HPVjfV9yrq+J0+eoLKyEj169BBRdeKPgk/KcDgcuLu7Iy0tDbt27QIAlJeXw9PTE+bm5rCwsIC8vDzu3r2LoKAg2NnZyXQrmRBJNWXKFNTU1ODixYsffF5UVBSGDBlC++K+RWoWXsXExMDBwYHtMsSCiooKzp8/j0GDBiEkJATh4eEwMjLCqlWrMGHCBJrZRYgUkJOTw+bNm7F582ZMnDjxvcFG3ZwNSUWLr6qqCqmpqdRVB6C0tBQuLi6YPHky5OXlERQUBD8/PwQGBmLKlCkUeoRIEUtLS/B4PAQEBLz3OTSjsyGpCL7k5GT07NkTTZs2ZbsUVjAMg7CwMDg4OKBbt264efMmtm7ditzcXBw6dAjOzs548eIF22USQgTs7VZfY2N9PB4P0dHRFHzvkIrgk/YTGd6nqKgIe/bsQd++fTFv3jz07dsX6enp8PPzw9ixYyEvL485c+bA0tISNjY24HK5bJdMCBEwS0tLAMCFCxcaPJaWloa2bduibdu2oi5LrEnFOr4FCxZAT08PS5cuZbsUoePxeLh58ybc3Nzwzz//wNLSEo6Ojhg2bNh7+/hra2sxYcIEaGtri/U5foSQL3PhwgVs2rQJ10LCcTbuKdLyS1FayUXhk8coyb6Pc7vXok1zOimljlQEn4GBAQ4cOAATExO2SxGaJ0+e4OjRo3B3d4eamhqcnJxga2sLNTW1T3p9cXExjIyMsHbtWsyfP1+4xRJCRCo+5yWsNrmB6aALeXl5VHF5/MfkwYOCggKGa6tjsYUW9LuqsVeomJD44KvbsaWoqEjqxvi4XC4uX74MNzc3hIaGwsbGBo6Ojhg0aNAXTU1OT0+Hubk5zp49C1NTUyFUTAgRtRMRWdgamIbKGi4YvP/3AocDKCvIY8N4Hcwy7i66AsWQxC9nkMaJLQ8fPoS7uzuOHTuGHj16wNHRESdPnkSzZs2+6rra2trw9PSElZUVIiIioKGhIaCKCSFseBN6qaio4QEfCD0AYBigoqYWWwNTAUCmw0/iJ7dIy8L1yspK+Pr6YtSoUTAxMUFVVRVu3LiBu3fvYu7cuV8denXGjh2L1atXw9LSEq9fvxbINQkhopeQU4ytgWn/H3r/aamsgP1W/RD9gzluLDPBd/3a1Xu8ooaHrYFpSMwtFmG14oWCj2XJyclYuXIlunbtiqNHj8LZ2Rk5OTnYvXs3+vTpI5R7rlq1Cvr6+nBwcPiiAy0JIew7eDsTldyGB1D/NK43amp5MN8TirXn7+PncdrQUq/fI1bJrcWh25miKlXsUPCxoKysDO7u7jAxMcG3336LFi1aIDIyEteuXYO1tTWUlIQ7+4rD4cDFxQU5OTnYunWrUO9FCBG8orIqBGcU4t3vrSqKchijq479tx+hvKYWsTklCMoowsT+Heo9j2GAoPRCPC+rEmHV4kOix/iqq6tx//59DBgwgO1SPophGERFRcHNzQ1+fn6wsLDAhg0b8O2330JBQfT/G5SVlXH27FkYGRmhb9++mDJlishrIIR8Gf+Y3EZ/3r1NU3B5DLJf/Hc6S3pBGQy7qTV4LgeAf2wunM17CqlK8SXRwZecnIwePXqI9cSWFy9ewNvbG25ubigrK4OjoyNSUlLQqVMntktDx44dcfbsWYwfPx5aWlro378/2yURQj5BWn5pvSULdZoqyuN1Vf2NKl5VcdGsiXyD51ZyeUjLeyW0GsWZRHd1ims3J8MwuH37NmbNmoUePXogPDwce/fuxYMHD7Bu3TqxCL06hoaG2LdvHywtLVFUVMR2OYSQT1Ba2fguTOU1tWimVL8901xJAa+rG44FvrlOjcBrkwQS3eITt+DLz8/H8ePH4ebmBiUlJTg5OWHfvn1o06YN26V90MyZM5GYmIjp06fj+vXrtJE1IWIqOzsbwcHBuB//GlBuuBwp63k5FOQ46NZahd/dqd2+OTILG5/Braosm591avF9pdraWgQGBmLq1KnQ1dXFgwcP4OXlhaSkJKxYsULsQ6/Ob7/9hhYtWmDFihVsl0IIwZueowcPHsDd3R2zZ89Gt27dMGTIEFy6dAm92zVHI72XqKjh4XpaIZZaaEJFUQ4Du7TEyN5tcTEpv8FzlRXkoNOxhQjeifiR2J1bqquroaamhsLCQoGtcfsc2dnZ8PDwgIeHBzp27AgnJyfMmDEDLVpI7l+k0tJSGBsbY9myZVi0aBHb5RAiUxiGQWpqKoKDgxESEoLg4GDIycnBwsKC/0/v3r3B4XBQVFYF0x23Gh3na6msgN8m6cBEszVKKmqw59ZDXE5+1uB5SgpyCPthpEzu4SmxXZ0pKSno0aOHSEOvuroaAQEBcHNzQ3R0NGxtbXHp0iWpOQdQVVUVAQEBMDU1ha6uLoYPH852SYRILR6Ph6SkJAQHByM4OBh37txB8+bNYWFhgbFjx2Lr1q3Q1NRsdHvCts2VYNFbHddTCxosaSip5GLZ6eQP3pvDAUZoq8tk6AESHHzR0dEi6+ZMS0uDu7s7PD090adPHzg6OuLcuXNQUVERyf1FSUtLCz4+PpgxYwbCw8OhqanJdkmESAUul4u4uDh+a+7u3bto164dzM3NMXXqVPz555/o2rXrJ19vyXAt3HlQhIqaxieufIiygjwWD9f67NdJC4kNPmGP75WXl8Pf3x9ubm7IyMjA3LlzcffuXfTq1Uto9xQXo0aNwoYNGzBp0iSEhYVJdPctIWyprq5GdHQ0v+syLCwMGhoasLCwgL29PQ4fPowOHTp8/ELvod9VDRvG67y1V+enUVGUw4bxOtDrovbF95Z0EjvGN3jwYPz5558CP2UgLi4Obm5uOHnyJIyNjeHo6IgJEybI3ExHhmGwYMECFBUV4cyZM5CTk+h5UIQIXUVFBe7du8dv0UVGRqJ3794wNzeHhYUFzMzMhDLZjX86A7e2Qbfn2+h0hv9IZPAJemJLSUkJfH19ceTIERQVFWH+/PlwcHD4rG4HaVRdXY1Ro0ZhxIgR+OWXX9guhxCx8vr1a4SFhfFbdLGxsejXrx8sLCxgbm6OYcOGoWXLliKpJTG3GIduZyIovRAcvFmcXkdZQQ4M3ozpLR6uJdMtvToSE3xFZVXwj8lFWn4pcgueIy4yDGuc7GBl0OWLBmgZhkFYWBjc3Nxw/vx5jB49Go6Ojhg9ejTk5RuZJyyjnj17hiFDhmDXrl2wsrJiuxxCWFNSUoLQ0FD+ZJTk5GQMHDiQP+PSxMQEzZs3Z7XG52VV8I/NRVreK5RW1kBVWRE6HVtg+qAv+z0prcQ++BJyinHwdiaCMwoBoN703bpvMp9zsnBhYSG8vLzg5uYGHo8HR0dHzJ49G+3atfvoa2VVfHw8vvnmG1y7dg0DBw5kuxxCROL58+e4c+cOv0WXkZGBIUOG8Ft0RkZGUjnBTRaIdfAJqu+ax+Ph5s2bcHNzwz///ANLS0s4Ojpi2LBhX3SSuSzy8/PD6tWrERkZifbt27NdDiECV1BQwB+fCw4OxuPHj2FiYsJv0RkaGqJJkyZsl0kEQGyDr/7Jwp/mzWwlXX745ebm4tixY3B3d4eamhqcnJxga2sLNTU14RQt5TZt2oSbN2/i1q1b9AuASLzc3Nx6i8WfPXuGYcOG8SejDBw4kJWTU4jwiWXwJeQUY8aRiAbrU3ZM1oVx91ZQaSKPorJquIc9xpn4vHrPUVaUwxLtalw76YbQ0FDY2NjA0dGR9a3NpAGPx8P06dPRunVrHDlyhFrLRGIwDINHjx7xQy4kJASlpaX8kDM3N0f//v1pfF9GiGXwLfCKbnRHAi31psh+UYGaWgaabZri+OwBWOibiPv5ZfznMDweVF5k4EfTNrCysmJlOzNpVlZWhqFDh8LJyQnLli1juxxCGsUwDDIyMuq16Gpra/khZ2FhAV1dXfryJqPErh3/vpOFASCzsJz/ZwYMGAbQaK1SL/g4cnJgOvTBxOkj0awZzWIStObNmyMgIAAmJibQ1dXF6NGj2S6JEPB4PNy/f58/PhcSEgIlJSVYWFhgxIgR2LRpE7S0tCjoCAAxDL73nSxcZ+O43pis3wEqivK4n/cKIQ9eNHiOLJ8sLArdu3fHyZMnYW1tjdDQUGhpye7WR4QdtbW1SEhI4Lfm7ty5g1atWsHc3BwTJkzArl270K1bN7bLJGJK7Lo6V56Kw/n4px98jhwHGNClJQZ3U4N72GNweQ3fwpQBnbHXZoCQqiQA4Orqin379iEiIgKqqqpsl0OkWE1NDWJjY/mtudDQUHTs2JE/49LMzAydO3dmu0wiIcSuxfe+k4XfxmOA2JwSTOzfHjMMOuFE1JNGriObJwuLkrOzMxITE2Fra4sLFy7QxAAiMFVVVYiMjOS36CIiItCjRw+Ym5vDwcEBHh4etPaWfDGxCz5V5U8vSV6Og66tGl9A+vLZExQWdoe6urqgSiON+PPPPzFmzBj89NNP2L59O9vlEAlVXl6OiIgIfosuOjoaOjo6sLCwwNKlS3Hy5Em0bt2a7TKJlBC74NPpoAolhfwGByy2bqoII81WCM54jkpuLUw0W2N83/ZYcy6lwTXkwcOTlCj06jUXGhoaGDFiBEaMGAELCwu0atVKVG9FJigqKsLPzw9GRkbo378/bG1t2S6JSIBXr14hNDSU36JLSEiAnp4eLCws8MMPP2Do0KHUfU6ERuzG+N53snCrpor4c3o/aLdvBjkOB09LKnEiMhf+cXkNrlF3snBLZXnExMQgKCgIQUFBCAsLQ+/evflBaGZmRh8uAUlOTsbIkSNx+fJlDB48mO1yiJh5+fIl7t69y2/R3b9/H4aGhvylBSYmJmjatCnbZRIZIXbBB7x/Hd+n4HCAsX3aw2WWYYPHqqurERkZyQ/CyMhI9O3bFyNHjsSIESNgampK6/6+woULF7B06VJERkaiY8eObJdDWFRYWMjf5zI4OBgPHz6EsbExfzLK4MGDoayszHaZREaJZfC9b+eWT6GiKI9TC4w/6eiNyspKhIeH84MwLi4OAwYM4AehiYkJfTg/09atW3Hx4kXcvn2b/tvJkLy8vHqLxZ88eQJTU1N+i87AwEDmzrQk4kssgw8QzF6dn6vufK1bt24hKCgIycnJGDx4MD8IhwwZQntUfgTDMJg5cyaaNGmC48eP04JhKfX48eN6i8WfP38OMzMzfotOX1+fZvkSsSW2wQewf7JwaWkp7ty5w28RZmRkwMTEhB+EBgYGtIltI8rLyzFs2DDY2dnh+++/Z7sc8pUYhsHDhw/rtegqKirqbf/Vt29fyMnJsV0qIZ9ErIMPEK+ThV++fImQkBB+izA7OxvDhg3DiBEjMHLkSPqW+5acnBwYGRnB3d0d48aNY7sc8hkYhkFaWlq9Fh2Hw+G35szNzaGtrU2teSKxxD746ojjycKFhYUIDg7mB2FBQQHMzc35QSjr34LDwsIwefJkhISEQEdHh+1yyHvweDwkJSXVO7mgefPm/NachYUFNDU1KeiI1JCY4JMEeXl5uH37Nj8IS0pKMHz4cH4QyuK3ZA8PD+zYsQMRERG0hlJMcLlcxMfH81t0d+/ehbq6er0WXdeuXdkukxChoeATopycHP744K1bt1BdXc1fQzhixAj07NlTJoJw1apVSE1NxaVLl2hMlAXV1dWIjo7mt+jCwsKgoaFR7yy6Dh06sF0mISJDwScidQdhvh2ECgoK9YJQWneT53K5GD9+PPr374/du3ezXY7Uq6ysxL179/jdlvfu3UOvXr34IWdmZoa2bduyXSYhrKHgY0ndQZl1QRgUFIQWLVrUC8JOnTqxXabAvHz5EkZGRli/fj3mzp3LdjlSpW4ZTl2LLjY2Fn379uV3XZqamkJNTY3tMgkRGxR8YoJhGKSkpPBDMDg4GOrq6vwQHD58uMTvRp+amgoLCwtcuHABJiYmbJcjsUpKShAaGspv0SUlJWHgwIH8Ft3QoUPRvHlztsskRGxR8IkpHo+HhIQEfhDeuXMHXbt2rbfhtiTuVh8YGAgnJyfcu3cPXbp0YbscifD8+XP+PpfBwcHIyMjA4MGD+S06IyMjqKg0fkoJIaQhCj4JweVyERsbW2/DbS0trXobbrds2ZLtMj/Jrl27cOrUKYSEhNDGxI0oKChASEgIv+syOzsbJiYm/MkohoaGUFJiZwkPIdKAgk9C1dTUICoqir90IjIyErq6uvxdZYYNGya2G24zDIPZs2eDy+XCx8dHJma2fkhubm69NXT5+fkYNmwYv0U3cOBAmg1LiABR8EmJupl8dUEYGxsLfX39ehtui1N3WGVlJSwsLDB58mSsW7eO7XJEhmEYZGVl1dv+q7S0FObm5vwWXf/+/WkHIEKEiIJPSpWXl9fbcDspKQmGhob8IDQyMmJ9w+2nT5/CyMgIBw8exKRJk1itRVgYhsGDBw/qbf9VU1NTb7G4rq6uTO/wQ4ioUfDJiFevXuHu3bv8NYTp6ekwNjbmB6GhoSEr3WmRkZGYMGECgoKC0LdvX5HfX9B4PB7u379fr+tSUVGRH3QWFhbQ0tKS+e5dQthEwSejiouLERISwg/CrKwsmJqa8rdXGzBggMi6206cOIHNmzfj3r17aNOmjUjuKSi1tbVITEzkt+ju3LkDNTW1eicXdO/ene0yCSFvoeAjAICioiIEBwfzgzAvL6/ehtv9+vUTanfc2rVrERMTg6tXr4r1gaU1NTWIjY3lt+hCQ0PRsWPHett/de7cme0yCSEfQMFHGpWfn4/bt2/zl0+8fPkSFhYW/CDU0dERaHddbW0tJk6cCC0tLezfv5//86KyKvjH5CItvxSllVyoKitAp4MqrAxEcypHVVUVoqKi+N2W4eHh0NTU5Iecubm5xG8sQIisoeAjnyQ3N7fePqNVVVX8kydGjBghkHGrkpISGBkZ4fvvv8eQb61w8HYmgjMKAQBVjZzDOFxbHYsttKDfVe2r7vu28vJy/j6XwcHBiI6Oho6ODr9FN2zYMIncOIAQ8h8KPvJF3t5wOygoCBwOp94+o186rpWRkYHhjhvR3Gw2ahjgQ387ORxAWUEeG8brYJbxl93v1atX9fa5jI+Ph56eHr9FZ2pqClVV1S+6NiFEPFHwka9WN2X/7SBs1qxZvSD81HGvExFZ+OViCqp5H39uHRVFOWwYr/tJ4VdcXFxv+6/79+/DwMCAP+PS2NhYbBf+E0IEg4KPCBzDMEhNTeWvIbx9+zbatm1bb8Pt9u3bN3hdQk4xZhyJQEVNLf9nivIc/DyuN0w0W6OligJyXlZg761/cefhi3qvVVGUx6kFxtDrolbv50VFRfW2/8rMzISxsTG/63LIkCFQVlYWyn8HQoh4ouAjQsfj8ZCYmMhvDYaEhKBz5878NYQWFhZo06YNFnhF43pqQb3uTRVFOcwz0cC5hHzklVTCvFcb/DGlDyxdo/C0pJL/PA4HGNunPTaN6swPueDgYOTm5sLU1JTfdWlgYMD6wn1CCLso+IjI1dbWIi4ujt8iDA0NRXed/igb+QN4nI+vHTy3YDAOhWThelrhOxeuQZn3SgwbPIDfotPX16d9Lgkh9VDwEdbV1NRg08k7OHX/NWrx4bWCbZop4sZyE0w9HI1Hz8vrPdZEHvjfN9pYaKElzHIJIRKONggkrFNUVER5k1YfDT0FOQ52Tu6DCwn5DUIPAKprgfT8MmGVSQiREhR8RCyUVnI/+DgHwO+TdVFTy+C3qw8+cJ0aAVdGCJE2FHxELKgqf3gc7reJOmjTrAlW+CeDy3t/77yqsvhud0YIEQ8UfEQs6HRQhZJC438dN43vjR5tm2LJyaR6O7i8S1lBDjodWwirREKIlKDJLUQsFJVVwXTHrQbB1qmlEm4sH4oqbi1q32rpbb6cgUvJBfWeq6Qgh7AfRopkD09CiOSied5ELLRtrgSL3uoN1vE9LalCn1+DPvp6DgcYoa1OoUcI+Sjq6iRiY8lwLSgrfNkZgMoK8lg8nJYxEEI+joKPiA39rmrYMF4HKoqf99fyzV6dOg22KyOEkMZQVycRK3UbTW8NTEMlt1bopzMQQmQPTW4hYikxtxiHbmciKL0QHACVjZzHN0JbHYuHa1FLjxDyWSj4iFh7XlYF/9hcpOW9QmllDVSVFaHTsQWmDxLNCeyEEOlDwUcIIUSm0OQWQgghMoWCjxBCiEyh4COEECJTKPgIIYTIFAo+QgghMoWCjxBCiEyh4COEECJTKPgIIYTIFAo+QgghMoWCjxBCiEyh4COEECJTKPgIIYTIFAo+QgghMoWCjxBCiEyh4COEECJTKPgIIYTIFAo+QgghMoWCjxBCiEyh4COEECJTKPgIIYTIFAo+QgghMuX/ADSYAxzkj1h6AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "problem = get_random_maxcut_qp(degree=3, num_nodes=8, draw=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can get an approximation of the maximal cut of this graph using QRAO by encoding `problem` with a quantum random access code; constructing a `QuantumRandomAccessOptimizer` instance with our encoding, a minimum eigensolver, and the Pauli rounding scheme; solving our `problem` with the optimizer instance; and extracting the optimal function value from the `fval` property."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6.0"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "encoding = QuantumRandomAccessEncoding(max_vars_per_qubit=3)\n",
+    "encoding.encode(problem)\n",
+    "qrao = QuantumRandomAccessOptimizer(\n",
+    "    encoding=encoding, min_eigen_solver=NumPyMinimumEigensolver(), rounding_scheme=SemideterministicRounding()\n",
+    ")\n",
+    "found_maxcut = qrao.solve(problem).fval\n",
+    "found_maxcut"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we can compute the exact maximal cut of our graph using CPLEX by constructing a `CplexOptimizer` instance, solving `problem` with the optimizer instance, and extracting the optimal function value from the `fval` property."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "20.0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "exact_optimizer = CplexOptimizer()\n",
+    "exact_maxcut = exact_optimizer.solve(problem).fval\n",
+    "exact_maxcut"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we can evaluate the performance of QRAO by determining how closely it approximated the exact maximal cut of our graph. This can be measured using the **approximation ratio**, computed by dividing QRAO's approximate maximal cut by the exact maximal cut. If `approximation_ratio` is `1.0`, then QRAO found the exact maximal cut of the graph; more generally, the closer `approximation_ratio` is to `1.0`, the better QRAO approximated the maximal cut of the graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.3"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "approximation_ratio = found_maxcut / exact_maxcut\n",
+    "approximation_ratio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we know how to evaluate the performance of QRAO for a specific problem, we can generalize by defining a function that can compute the approximation ratio for solving MaxCut for a random 3-regular `num_nodes`-node graph using QRAO with `rounding_scheme` rounding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exact_optimizer = CplexOptimizer()\n",
+    "min_eigen_solver = NumPyMinimumEigensolver()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_approximation_ratio(num_nodes, rounding_scheme, degree=3):\n",
+    "    problem = get_random_maxcut_qp(degree=degree, num_nodes=num_nodes)\n",
+    "\n",
+    "    exact_fval = exact_optimizer.solve(problem).fval\n",
+    "\n",
+    "    encoding = QuantumRandomAccessEncoding(max_vars_per_qubit=3)\n",
+    "    encoding.encode(problem)\n",
+    "    qrao = QuantumRandomAccessOptimizer(\n",
+    "        encoding=encoding, min_eigen_solver=min_eigen_solver, rounding_scheme=rounding_scheme\n",
+    "    )\n",
+    "    approximate_fval = qrao.solve(problem).fval\n",
+    "\n",
+    "    approximation_ratio = approximate_fval / exact_fval\n",
+    "\n",
+    "    return approximation_ratio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we are equipped to evaluate the performance of QRAO by determining how closely it approximates the exact solution to MaxCut for 100 random 3-regular graphs.\n",
+    "\n",
+    "There are a couple performance questions we want to investigate:\n",
+    "\n",
+    "1. How does the **rounding scheme** affect the performance? Does one rounding scheme outperform another? How does this change for larger graphs?\n",
+    "2. How does the **number of nodes in the graph** affect the performance? Is the performance better/worse for larger graphs? How does this change between rounding schemes?\n",
+    "\n",
+    "We can tackle these questions by comparing the distribution of approximation ratio for 100 random 3-regular graphs with 8, 16, 24, 32, 36, and 40 nodes using QRAO with Pauli rounding and magic rounding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NUM_NODES_LIST = [8, 16, 24, 32, 36, 40]\n",
+    "TRIALS = 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pauli_rounding = SemideterministicRounding()\n",
+    "\n",
+    "backend = Aer.get_backend(\"aer_simulator\")\n",
+    "rounding_qi = QuantumInstance(backend=backend, shots=1)\n",
+    "\n",
+    "magic_rounding = MagicRounding(rounding_qi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9062328d194d425ca11ee4103f33fa66",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "53364be828924f61a59e2a2cdf4a9f54",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "75f645994b234ec18a01bb562422bf22",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7a854d47e7ef44a686abfa5e886af5f2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "04c0344b049346e2b6c333691125eb9b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8e62c41abc2e48c98971b58416476257",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pauli_rounding_approximation_ratios = { num_nodes : [ compute_approximation_ratio(num_nodes, pauli_rounding) for _ in tqdm(range(TRIALS)) ] for num_nodes in NUM_NODES_LIST }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we can see the approximation ratio distribution for using **QRAO with Pauli rounding** to solve 100 random 3-regular graph MaxCut instances for different graph sizes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmEAAAKVCAYAAACH9jxEAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAABBZklEQVR4nO3de5glVXnv8e/P4eJBFC9DLnJrVCRnNIo6QsxFjCHJIAaMwQhGRQ+GxBPExMQjiYkSEg3eNYpHUVHRKCqJnkkYJQZBzUXDIKiAYhBHGbxlEPGCogPv+aNqYNN0711zqa7u3d/P8/QzVatW1X736t3Tb6+1alWqCkmSJC2sOw0dgCRJ0nJkEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkxZYklVJ1idJj68xk6SS7NTufzDJcX293o7Sxny/dvsNSf5iB1xz1ySfT7Ln9ke4fCQ5MMmlSb6b5KSh45GmkUmYplaSpyX5bJIbk3w9yeuT7DFy/JQkP07yvSTfTvLvSR4xx3XelmRzkp+e49hjk/xnku8nuS7J3yXZe0JofwW8vNpF+pJsSPKDNo5vtK+3+/a+/1FVdXhVvX2uY13bYaFV1e9X1V/tgOvcBJwJnDxfnbYNKsmzZ5U/uy0/ZXvjaK93cJJ1bTt/q/3sPL3juW9L8tcT6lT7WfxekmuTvDLJim0M9/8AF1TVXavqb7fxGpLGMAnTVEryx8BLgOcCewA/B8wA/5xk55Gq76mq3YGVwAXA+2Zd5y7AbwE3AE+edexo4F3Aq9vzHwDcBPxrknvME9dPA78MfGDWod9o43gosBr48615vzvA2HaYAu8Cjkuy65g6XwCeOqvsuLZ8u7WJ7UeAjwL3A+4FPBM4fEdcf8SD2+/lrwBPAn53K+Pcqd3cD7h8WwIYuYakMUzCNHWS3A34S+BZVfWhqvpxVW0Afhu4D80vptupqs3A3wF7zRq2+i3g28CpNL+Qt7xGgFcAf11V76qqH1TV14FnAN8D/mie8H4V+FRV/XCug1V1LfBB4IFJ7pHkn5L8d5Lr2+1be9naHrTDRvZPSfLOedrkwiTPmCemse2Q5N5J1rY9N1clufWX+uzemSSPSrJxVox/kuQzSW5I8p4kdx45/twkX0vy1ST/a1bMt157y3WT/HGSb7bnPH2k7r2S/GOS7yS5KMlfJ/nXkfe1EbieJhmfz0XAbkke0F7zAcCd2/ItrzPv9yTJPdsYf6Pd371try2J3cuAt1fVS6pqUzUurqrfbus/bTTmtqyS3C/JCcDvAP+n7eX6xzHvY8t7/jzwceCB7bUem2Z4cUtv54NGXmdDkucl+Qzw/SQfoflj4XXt690/yR5Jzmrf+5eT/HmSO43E/m9JXpXkOuCU9vv3+jRD4d9rj/9Ukle3bff5JA8ZieHkJF9MM/x5RZLfHDn2tCT/muTl7blfSnL4yPF7Jnlr+zm6PskHRo7N+76loZmEaRr9PM0vz38YLayq7wHrgF+bfUKSXWh6Qa6j+WW9xXHAu4GzgZ9J8rC2/EBgX2b1GFXVLcDf0yRbc/lZ4Mr5Ak+yD/AY4BKan8+30vRI7Av8AHjdfOfuCPO0w9nARuDewNHAi5M8eisu+9vAGmB/4EHA09rXWgP8CU1bHQAcNs/5W/wUTa/mXsDxwOm5rcfxdOD7bZ3jGEmYR3wOePCE13gHt/WGHdfuj5r3e1JV3wL+F/CmJD8BvAq4tKrOSrIb8AjgnAmvP6eqOoMmOX5pVe1eVb8x6Zwkq4BfAi5pk50zgd+j6YF7I7A2t+8ZPBY4Arh7VT2aJoE7sX29LwCvpWn/+wCH0rTT6FDqIcDVwE8CL2rLfpumV3clTS/xfwCfavfPAV45cv4X23j3oPkj6p25/RSAQ2h+dlYCLwXektw6r/IdwG40vdFb2p6O71sajEmYptFKYFPbqzPb14DRnq7fTvJtml+mvwscveW8JPvS9Aa8q6q+AZzPbb+gV45cb67XWDlHOcDdge/OUf6BNo5/pRmuenFVXVdVf19VN1bVd2l+sR06z3W315zt0CaFvwA8r6p+WFWXAm/mjsN24/xtVX21TVL+EThoy2sCb62qy6rq+8ApE67zY+DUtmdzHU2P44Fp5jz9FvDCtq2uAOaa//ZdmvYf553AsWmGrI9p92816XtSVf9Mk5ifT5NM/1576B40/9/O9XnZ0T6V5Hqatn4zTdJ4AvDGqvpkVd3czg+8idv3DP5tVV1TVT+YfcG2jY8B/rSqvtv2LL8CeMpIta9W1WuravPINd7f9vb9EHg/8MOqOquqbgbeA9zaE1ZV72s/J7dU1XuA/wIOHrn+l6vqTe25bwd+GvjJNlE7HPj9qrq+/Xx8tD2ny/uWBmMSpmm0CViZueel/HR7fIv3VtXdaf56vwx42MixpwCfaxMPaHointT+gt5yjTtM1p/jNUZdD9x1jvLHVdXdq2q/qvrfVfWDJLsleWM79PMd4GPA3bPtE63Hma8d7g18q004tvgyTW9UV18f2b4R2HLTwb2Ba2Zdd5zrZiXWW661J7DTrGuNbm9xV5qh5XlV1VeAq4AXA/9VVbe7TsfvyRk0Q4Bvq6rr2rLrgVuY+/Oyoz20qu5RVfetqj9ve2f3A/64HZL7dptw70PzPdhirjbbYiWwM7f/Hs3+HMx1/jdGtn8wx/6tN6AkeerIsOG3adpw9I+ZWz9HVXVju7l7+z6+VVWjPdhbdHnf0mBMwjSN/oPmr93HjxamuePwcODC2SdU1Saav5pPGRkCeSpwnzR3Vn6dZuhkJU0Px5U0Q3RPmPUad6LplTl/ntg+A9y/4/v4Y5phz0Oq6m7AI7e8TPvv92mGYLb4qY7Xndcc7fBV4J5JRhPHfYFrd0AMX6P5hTh63W3x38BmYPSu1H3mqPc/gU93uN5ZNG1/1hzHxn5P2mTsjPbc/512uY02afgPms/GfG7Xlklmt2V1iH0+1wAvahP9LV+7VdW7O15/E01P5H4jZaOfg+2KL8l+wJuAE4F7tX8QXMZtn/VxrqH5jN59nmOT3rc0GJMwTZ2quoFmTslrk6xJsnOSGeC9NL9M/m6e864EzqOZ/PwI4L40wyEHtV8PpLnL7qlVVTTzmf48yZOS3Ln9pflm4G60c1Lm8GHgoRmZnD7GXWl6C76d5J7AC2cdvxQ4pn1/q2nma2230XZoe4L+Hfib9j0+iGY+1pZhukuBx7QTo38K+MOteKn3Ak9Ls27abtzx/XWN92aa+X+ntD1VP8Os4dIkewH3BD7R4ZLvoZk3+N45jk36nvwZTTLyv2gm4p810kv2f2je73OT3KuN68FJzm6Pfxp4QJKD2s/HKbOu/Q2a+Vjb4k3A7yc5JI27JDliVnI9r7aN3wu8KMld26TpOcwart0Od6Fpt/8GSHPTxQM7xvY1mptZXp/mxomdk2xJjrfrfUt9MwnTVKqql9L8Qnw5zVygL9H0MhzWzj+az8toeoJ+F/h/VfXZqvr6li/gNcBjk9yznbfyFJo7Ia8DrgD+B/ALI8NQs+P6Bs0yBUd1eBuvbq+3iSZ5+NCs439BkyheT5N0vqvDNbt6GXBCO8H8WJrlPb5KM6/nhVX1L229d9AkDxuAf6ZJYDqpqg/SvMeP0AwBfmQ74j2RZkL319uY3k3TG7rFk2juTLxpjnNnx/WDqvqXueZGMeZ70t608RyaJP1mmiVSinZ9sqr6d+DR7dfVSb5F02u2rj3+BZq7cP+FZj7U7e6UBN4CrGqH1T4w6X3Mek/raT7Tr6P5vFxFe4PEVngWTW/d1W1s76KZ9L7d2nl8r6DpLfwGzQ0s/7YVl3gKTU/d54Fv0v4xsIPet9SbNH/QS9Ot/cv6VJoE6SsDx7KKZmLxweUPYC+SvAT4qarasjbYp4FHVtU3Bw5Nkm5lEqZlI8lTgB9X1dkTK2tJaYcgdwE+CzycpnfpGVX1gSHjkqRxTMIkLXlJHk4zBHlvmuGsM4DT7GmUtJiZhEmSJA3AifmSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkawE5DB7C1Vq5cWTMzM0OHIUmSNNHFF1+8qar2nOvYkkvCZmZmWL9+/dBhSJIkTZTky/MdczhSkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjSAnYYOQJIkaUeaOfncTvU2nHZEz5GMZ0+YJEnSAEzCJEmSBmASJkmSNACTMEmSpAFMTMKSvDTJ3ZLsnOT8JP+d5MkLEZwkSdK06tIT9mtV9R3gscAG4H7Ac/sMSpIkadp1ScK2LGNxBPC+qrqhx3gkSZKWhS7rhP1Tks8DPwCemWRP4If9hiVJkjTdJvaEVdXJwM8Dq6vqx8CNwFF9ByZJkjTNukzM3w3438D/bYvuDazuMyhJkqRp12VO2FuBH9H0hgFcC/x1bxFJkiQtA12SsPtW1UuBHwNU1Y1Aeo1KkiRpynVJwn6U5H8ABZDkvsBNvUYlSZI05brcHflC4EPAPkn+DvgF4Gl9BiVJkjTtJiZhVfXhJJ8Cfo5mGPLZVbWp98gkSZKm2LxJWJKHzir6Wvvvvkn2rapP9ReWJEnSdBvXE/aK9t870yxJ8WmanrAHAeuBR/QbmiRJms/Myed2qrfhtCN6jkTbat6J+VX1y1X1yzQ9YA+tqtVV9TDgITTLVEiSJGkbdbk78sCq+uyWnaq6DPifXS6eZE2SK5NcleTkOY4/J8kVST6T5Pwk+3UPXZIkaenqkoR9Jsmbkzyq/XoT8JlJJyVZAZwOHA6sAo5NsmpWtUtoHof0IOAc4KVbF74kSdLS1CUJezpwOfDs9uuKtmySg4GrqurqqvoRcDaznjlZVRe0i78CfALYu2vgkiRJS1mXJSp+mOR04F9oFmy9sn2Q9yR7AdeM7G8EDhlT/3jggx2uK0mStORNTMKSPAp4O7CB5u7IfZIcV1Uf21FBJHkyzR2Yh85z/ATgBIB99913R72sJEnSYLqsmP8K4Neq6kqAJPcH3g08bMJ51wL7jOzvzRx3VSY5DHg+cGhVzfk4pKo6AzgDYPXq1dUhZkmSpEWty5ywnbckYABV9QVg5w7nXQQckGT/JLsAxwBrRyskeQjwRuDIqvpm97AlSZKWti49YeuTvBl4Z7v/OzSLtY5VVZuTnAicB6wAzqyqy5OcCqyvqrXAy4DdgfclAfhKVR25De9DkiRpSemShD0T+APgpHb/48Dru1y8qtYB62aVvWBk+7BuYUqSJE2XLndH3gS8sv2SJEnSDtDl7shfAE4B9hutX1X36S8sSZKk6dZlOPItwB8BFwM39xuOJEnS8tAlCbuhqlxEVZIkaQfqkoRdkORlwD8At67jVVWf6i0qSZKkKdclCdvyqKHVI2UFPHrHhyNJy8/Myed2qrfhtCN6jkTSQupyd+QvL0QgkiRJy0mXnjBJ2i5de3rA3h5Jy0eXxxZJkiRpBzMJkyRJGsC8w5EjD93+alX9S5InAT8PfA44o6p+vEAxSpIkTZ1xc8Le2h7fLclxNA/a/gfgV4CDgeP6D0+SJGk6jUvCfraqHpRkJ+Ba4N5VdXOSdwKfXpjwJEmSptO4OWF3aock7wrsBuzRlu8K7Nx3YJIkSdNsXE/YW4DPAyuA5wPvS3I18HPA2QsQmyRpmXMhW02zeZOwqnpVkve0219NchZwGPCmqvrPhQpQkiRpGo1drLWqvjqy/W3gnL4DkiRJWg5cJ0ySJGkAJmGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkawNhnR0rqbubkczvX3XDaET1GIklaCuwJkyRJGkCvPWFJ1gCvAVYAb66q02Yd3xU4C3gYcB3wxKra0GdMXdijIUmS+tZbT1iSFcDpwOHAKuDYJKtmVTseuL6q7ge8CnhJX/FIkiQtJn32hB0MXFVVVwMkORs4CrhipM5RwCnt9jnA65KkqqrHuCRJW6Hr6IAjA9LW6XNO2F7ANSP7G9uyOetU1WbgBuBePcYkSZK0KKSvTqckRwNrquoZ7f5TgEOq6sSROpe1dTa2+19s62yada0TgBPa3QOBK3sJ+jYrgU0Tay1vttF4ts9kttF4ts9kttF4ts9kC9FG+1XVnnMd6HM48lpgn5H9vduyuepsTLITsAfNBP3bqaozgDN6ivMOkqyvqtUL9XpLkW00nu0zmW00nu0zmW00nu0z2dBt1Odw5EXAAUn2T7ILcAywdladtcBx7fbRwEecDyZJkpaD3nrCqmpzkhOB82iWqDizqi5PciqwvqrWAm8B3pHkKuBbNImaJEnS1Ot1nbCqWgesm1X2gpHtHwJP6DOGbbRgQ59LmG00nu0zmW00nu0zmW00nu0z2aBt1NvEfEmSJM3PxxZJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNoNfHFvVh5cqVNTMzM3QYkiRJE1188cWbqmrPuY4tuSRsZmaG9evXDx2GJEnSREm+PN8xhyMlSZIGYBImSZI0gCU3HClJkjTJzMnnTqyz4bQjFiCS+dkTJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAE5OwJPdNsmu7/agkJyW5e++RSZIkTbEuPWF/D9yc5H7AGcA+wLt6jUqSJGnKdUnCbqmqzcBvAq+tqucCP91vWJIkSdOtSxL24yTHAscB/9SW7dxfSJIkSdOvSxL2dOARwIuq6ktJ9gfe0W9YkiRJ022nSRWq6ookzwP2bfe/BLyk78AkSZKmWZe7I38DuBT4ULt/UJK1PcclSZI01boMR54CHAx8G6CqLgXu01tEkiRJy0CniflVdcOsslv6CEaSJGm5mDgnDLg8yZOAFUkOAE4C/r3fsCRJkqZbl56wZwEPAG4C3g18B/jDHmOSJEmael3ujrwReH77JUmSpB1g3iQsyT8CNd/xqjqyl4gkSZKWgXE9YS9v/3088FPAO9v9Y4Fv9BmUJEnStJs3CauqjwIkeUVVrR459I9J1vcemSRJ0hTrMjH/LkluXResfWzRXfoLSZIkafp1WaLij4ALk1wNBNgPOKHXqCRJkqZcl7sjP9SuD/YzbdHnq+qmfsOSJEmabl2eHbkz8HvAX7Rfv9uWTZRkTZIrk1yV5OQ5jj8nyRVJPpPk/CT7be0bkCRJWoq6zAn7v8DDgNe3Xw9ry8ZKsgI4HTgcWAUcm2TVrGqXAKur6kHAOcBLu4cuSZK0dHWZE/bwqnrwyP5Hkny6w3kHA1dV1dUASc4GjgKu2FKhqi4Yqf8J4MkdritJkrTkdekJuznJfbfstHdK3tzhvL2Aa0b2N7Zl8zke+GCH60qSJC15XXrCngtcMOvuyKfvyCCSPBlYDRw6z/ETaO/I3HfffXfkS0uSJA2iy92R57d3Rx7YFl3Z8e7Ia4F9Rvb3bstuJ8lhNM+lPHS+61bVGcAZAKtXr573UUqSJElLRZeeMGgm48+09Q9KQlWdNeGci4AD2sVdrwWOAZ40WiHJQ4A3Amuq6ptbE7gkSdJSNjEJS/IO4L7Apdw2F6yAsUlYVW1OciJwHrACOLOqLk9yKrC+qtYCLwN2B96XBOArPhhckiQtB116wlYDq6pqq4cBq2odsG5W2QtGtg/b2mtKkiRNgy53R14G/FTfgUiSJC0nXXrCVgJXJPlP4NaJ8w4bSpIkbbsuSdgpfQchSZK03HRZouKjCxGIJEnSctJlTpgkSZJ2MJMwSZKkAWxVEpbkXn0FIkmStJzMOycsyWnAy6tqU5LVwHuBW5LsDDzVuWKSJGlrzJx87sQ6G047YgEiWRzG9YQdUVWb2u2XAU+sqvsBvwq8ovfIJEmSpti4JGynJFt6yv5HVV0EUFVfAHbtPTJJkqQpNi4Jez2wLsmjgQ8leU2SQ5P8Jc1zJCVJkrSN5p0TVlWvTfJZ4JnA/du6BwAfAP56QaKTJEmaUmMXa62qC4ELFyQSSZKkZWSb1glL8vQdHYgkSdJysq2Ltf7lDo1CkiRpmRm3Tthn5jsE/GQ/4UiSJC0P4+aE/STw68D1s8oD/HtvEUmSJC0D45KwfwJ2r6pLZx9IcmFfAUmSJC0H45aoOH7MsSf1E44kSdLysK0T8yVJkrQdxq4TJkmSuvMB1doa9oRJkiQNwJ4wSZK03br0Aur27AmTJEkagD1hkiRNKeeoLW72hEmSJA3AnjBJkpYg52AtffaESZIkDcCeMElSZ8t5jpE9T9rR7AmTJEkaQK89YUnWAK8BVgBvrqrTZh3fFTgLeBhwHfDEqtrQZ0y6veX8V+2OYhsujB3VC+H3Yn6LrafHny1Nu956wpKsAE4HDgdWAccmWTWr2vHA9VV1P+BVwEv6ikeSJGkx6bMn7GDgqqq6GiDJ2cBRwBUjdY4CTmm3zwFelyRVVT3Gpa00rX+N+r4W5jqLzaT3tdjekz2A403r51TLQ59zwvYCrhnZ39iWzVmnqjYDNwD36jEmSZKkRSF9dTolORpYU1XPaPefAhxSVSeO1LmsrbOx3f9iW2fTrGudAJzQ7h4IXNlL0LdZCWyaWGt5s43Gs30ms43Gs30ms43Gs30mW4g22q+q9pzrQJ/DkdcC+4zs792WzVVnY5KdgD1oJujfTlWdAZzRU5x3kGR9Va1eqNdbimyj8WyfyWyj8WyfyWyj8WyfyYZuoz6HIy8CDkiyf5JdgGOAtbPqrAWOa7ePBj7ifDBJkrQc9NYTVlWbk5wInEezRMWZVXV5klOB9VW1FngL8I4kVwHfoknUJEmSpl6v64RV1Tpg3ayyF4xs/xB4Qp8xbKMFG/pcwmyj8WyfyWyj8WyfyWyj8WyfyQZto94m5kuSJGl+PrZIkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJA+j12ZF9WLlyZc3MzAwdhiRJ0kQXX3zxpqrac65jSy4Jm5mZYf369UOHIUmSNFGSL893zOFISZKkAZiESZIkDcAkTJIkaQAmYZIkSQMwCZMkSRqASZgkSdIATMIkSZIGYBImSZI0AJMwSZKkAZiESZIkDcAkTJIkaQAmYZIkSQMwCZMkSRqASZgkSdIAJiZhSe6S5E7t9v2THJlk5/5DkyRJml5desI+Btw5yV7APwNPAd7WZ1CSJEnTrksSlqq6EXg88PqqegLwgH7DkiRJmm6dkrAkjwB+Bzi3LVvRX0iSJEnTr0sS9ofAnwLvr6rLk9wHuKDXqCRJkqbcTpMqVNVHgY8m2a3dvxo4qe/AJEmSplmXuyMfkeQK4PPt/oOTvL73yCRJkqZYl+HIVwO/DlwHUFWfBh7ZY0ySJElTr9NirVV1zayim3uIRZIkadmYOCcMuCbJzwPVLtL6bOBz/YYlSZI03br0hP0+8AfAXsC1wEHtviRJkrZRl7sjN9GsESZJktSbmZPPnffYhtOOWMBIFsa8SViS1wI13/GqcpkKSZKkbTRuOHI9cDFwZ+ChwH+1XwcBu/QemSRJ0hSbtyesqt4OkOSZwC9W1eZ2/w3AxxcmPEmSpOnUZWL+PYC7jezv3pZJkiRpG3VZouI04JIkFwChWaj1lD6DkiRJmnZd7o58a5IPAofQTNR/XlV9vffIJEmSplinFfOBg4FfoukFe3jXiydZk+TKJFclOXmO489JckWSzyQ5P8l+Xa8tSZK0lHV5gPdpNKvkX9F+nZTkxR3OWwGcDhwOrAKOTbJqVrVLgNVV9SDgHOClWxe+JEnS0tRlTthjgIOq6haAJG+nSZ7+bMJ5BwNXVdXV7XlnA0fRJHIAVNUFI/U/ATy5e+iSJElLV9fhyLuPbO/R8Zy9gNEHf29sy+ZzPPDBjteWJEla0rr0hP0Nd7w78g7zu7ZHkicDq4FD5zl+AnACwL777rsjX1qSJE2xxfwopC53R747yYXcNiG/692R1wL7jOzv3ZbdTpLDgOcDh1bVTfPEcAZwBsDq1avnfZSSJEnSUtGlJwyaYctNbf37J7l/VX1swjkXAQck2Z8m+ToGeNJohSQPAd4IrKmqb25V5JIkaTCLuYdpqZiYhCV5CfBE4HLglra4gLFJWFVtTnIicB6wAjizqi5PciqwvqrWAi+jWYH/fUkAvlJVR27rm5EkSVoquvSEPQ44cL6hwnGqah2wblbZC0a2D9vaa0qSJE2DLndHXg3s3HcgkiRJy0mXnrAbgUuTnA/c2htWVSf1FpUkSdKU65KErW2/JEmStIN0WaLi7QsRiCRJ0nLSdcV8SZIk7UAmYZIkSQPYqiQsyU/0FYgkSdJyMu+csCT3nF0E/Ge7yn2q6lu9RiZJkjTFxk3M3wR8eVbZXsCnaFbMv09fQUmSJE27ccORzwWuBI6sqv2ran9gY7ttAiZJkrQd5k3CquoVwDOAFyR5ZZK70vSASZIkaTuNnZhfVRur6gnAhcCHgd0WIihJkqRp12XFfKpqbZIPA/ftOR5JkqRlYWxPWJKfSfIrSXavqh9U1WVt+ZqFCU+SJGk6zZuEJTkJ+H/As4DLkhw1cvjFfQcmSZI0zcYNR/4u8LCq+l6SGeCcJDNV9RqaNcMkSdIiN3PyufMe23DaEQsYiWYbl4Tdqaq+B1BVG5I8iiYR2w+TMEmSpO0ybk7YN5IctGWnTcgeC6wEfrbnuCRJkqbauCTsqcDXRwuqanNVPRV4ZK9RSZIkTbl5hyOrauOYY//WTziSJEnLw9glKiRJktQPkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJA+j0AG9JkrRjjFvBfhxXt58+9oRJkiQNwCRMkiRpAA5HSlqSfCixpKXOnjBJkqQB9NoTlmQN8BpgBfDmqjpt1vFdgbOAhwHXAU+sqg19xiRp4dlrtWPZntJ06K0nLMkK4HTgcGAVcGySVbOqHQ9cX1X3A14FvKSveCRJkhaTPnvCDgauqqqrAZKcDRwFXDFS5yjglHb7HOB1SVJV1WNc0qLSR6/GtPSUbOut/Av9ekupTbfFUvk8+bOkpabPOWF7AdeM7G9sy+asU1WbgRuAe/UYkyRJ0qKQvjqdkhwNrKmqZ7T7TwEOqaoTR+pc1tbZ2O5/sa2zada1TgBOaHcPBK7sJejbrAQ2Tay1vNlG49k+k9lG49k+k9lG49k+ky1EG+1XVXvOdaDP4chrgX1G9vduy+aqszHJTsAeNBP0b6eqzgDO6CnOO0iyvqpWL9TrLUW20Xi2z2S20Xi2z2S20Xi2z2RDt1Gfw5EXAQck2T/JLsAxwNpZddYCx7XbRwMfcT6YJElaDnrrCauqzUlOBM6jWaLizKq6PMmpwPqqWgu8BXhHkquAb9EkapIkSVOv13XCqmodsG5W2QtGtn8IPKHPGLbRgg19LmG20Xi2z2S20Xi2z2S20Xi2z2SDtlFvE/MlSZI0Px9bJEmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAH0+uzIPqxcubJmZmaGDkOSJGmiiy++eFNV7TnXsSWXhM3MzLB+/fqhw5AkSZooyZfnO+ZwpCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJA5iYhCW5S5I7tdv3T3Jkkp37D02SJGl6dekJ+xhw5yR7Af8MPAV4W59BSZIkTbudOtRJVd2Y5Hjg9VX10iSX9hyXJEnSHcycfO6t2xtOO2LASLZfl56wJHkE8DvAlne+or+QJEmSpl+XJOwPgT8F3l9Vlye5D3BBr1FJkiRNuYnDkVX1UeCjSXZr968GTuo7MEmSpGnW5e7IRyS5Avh8u//gJK/vPTJJkqQp1mU48tXArwPXAVTVp4FH9hiTJEnS1Ou0WGtVXTOr6OYeYpEkSVo2uixRcU2SnweqXaT12cDn+g1LkiRpunXpCft94A+AvYBrgYPafUmSJG2jLndHbqJZI0ySJEk7yLxJWJLXAjXf8apymQpJkqRtNG44cj1wMXBn4KHAf7VfBwG79B6ZJEnSFJu3J6yq3g6Q5JnAL1bV5nb/DcDHFyY8SZKk6dRlYv49gLuN7O/elkmSJGkbdVmi4jTgkiQXAKFZqPWUPoOSJEmadhN7wqrqrcAhwPuBvwcesWWocpIka5JcmeSqJCfPcfw5Sa5I8pkk5yfZb2vfgCRJ0lLUacV84GDgl2h6wR7e5YQkK4DTgcOBVcCxSVbNqnYJsLqqHgScA7y0YzySJElLWpcHeJ9Gs0r+Fe3XSUle3OHaBwNXVdXVVfUj4GzgqNEKVXVBVd3Y7n4C2HtrgpckSVqquswJewxwUFXdApDk7TQ9WH824by9gNFnTm6kGdacz/HABzvEI0mStOR1ScIA7g58q93eY0cHkeTJwGrg0HmOnwCcALDvvvvu6JeXJElacF2SsL/hjndH3mGS/RyuBfYZ2d+7LbudJIcBzwcOraqb5rpQVZ0BnAGwevXqeVfxlyRJWiq6PDvy3Uku5LYJ+c+rqq93uPZFwAFJ9qdJvo4BnjRaIclDgDcCa6rqm1sTuCRJ0lLW9e7IOwGbgG8D90/yyEkntCvsnwicB3wOeG9VXZ7k1CRHttVeRrP46/uSXJpk7da+AUmSpKVoYk9YkpcATwQuB25piwv42KRzq2odsG5W2QtGtg/bmmAlSZKmRZc5YY8DDpxvvpYkSZK2XpfhyKuBnfsORJIkaTnp0hN2I3BpkvOBW3vDquqk3qKSJEmacl2SsLXtlyRJknaQLktUdHpYtyRJkrrrukSFJEmSdiCTMEmSpAF0fXakJEnSNps5+VwANpx2xKKIA4aPZd6esCQrkvxekr9K8guzjv15/6FJkiRNr3HDkW8EDgWuA/42yStHjj2+16gkSZKm3Lgk7OCqelJVvRo4BNg9yT8k2RXIgkQnSZI0pcYlYbts2aiqzVV1AnAp8BGah25LkiRpG41LwtYnWTNaUFWnAm8FZvoMSpIkadrNe3dkVT15nvI3A2/uLSJJkjS1FtPdiUMbu0RFkoOBqqqLkqwC1gCfr6p1CxKdJEnSlJo3CUvyQuBwYKckH6aZnH8BcHKSh1TVixYoRkmSpKkzrifsaOAgYFfg68DeVfWdJC8HPgmYhEmSJG2jcUnY5qq6GbgxyRer6jsAVfWDJLcsTHiSJGkxcC7Xjjfu7sgfJdmt3X7YlsIkewAmYZIkSdthXE/YI6vqJoCqGk26dgaO6zUqSZKkKTduiYqb5infBGzqLSJJkqRlYOwSFZIkaTo4p2vxGTcnTJIkST0xCZMkSRqASZgkSdIATMIkSZIGYBImSZI0AO+OlCRpio3eFanFxZ4wSZKkAdgTJknSEuA6X9On156wJGuSXJnkqiQnz3F81yTvaY9/MslMn/FIkiQtFr31hCVZAZwO/CqwEbgoydqqumKk2vHA9VV1vyTHAC8BnthXTJIkLbSl3IM133yyLeVL7f0sNn0ORx4MXFVVVwMkORs4ChhNwo4CTmm3zwFelyRVVT3GJUlappZyQrQjmUQtDn0OR+4FXDOyv7Etm7NOVW0GbgDu1WNMkiRJi0L66nRKcjSwpqqe0e4/BTikqk4cqXNZW2dju//Fts6mWdc6ATih3T0QuLKXoG+zEtg0sdbyZhuNZ/tMZhuNZ/tMZhuNZ/tMthBttF9V7TnXgT6HI68F9hnZ37stm6vOxiQ7AXsA182+UFWdAZzRU5x3kGR9Va1eqNdbimyj8WyfyWyj8WyfyWyj8WyfyYZuoz6HIy8CDkiyf5JdgGOAtbPqrAWOa7ePBj7ifDBJkrQc9NYTVlWbk5wInAesAM6sqsuTnAqsr6q1wFuAdyS5CvgWTaImSZI09XpdrLWq1gHrZpW9YGT7h8AT+oxhGy3Y0OcSZhuNZ/tMZhuNZ/tMZhuNZ/tMNmgb9TYxX5IkSfPz2ZGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkaQK/PjuzDypUra2ZmZugwJEmSJrr44os3VdWecx1bcknYzMwM69evHzoMSZKkiZJ8eb5jDkdKkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjSAiUlYkrskuVO7ff8kRybZuf/QJEmSpleXnrCPAXdOshfwz8BTgLf1GZQkSdK065KEpapuBB4PvL6qngA8oN+wJEmSplunJCzJI4DfAc5ty1b0F5IkSdL065KE/SHwp8D7q+ryJPcBLug1KkmSpCm306QKVfVR4KNJdmv3rwZO6jswSZKkadbl7shHJLkC+Hy7/+Akr+89MkmSpCnWZTjy1cCvA9cBVNWngUf2GJMkSdLU67RYa1VdM6vo5h5ikSRJWjYmzgkDrkny80C1i7Q+G/hcv2FJkiRNty49Yb8P/AGwF3AtcFC7L0mSpG3U5e7ITTRrhEmSJGkHmTcJS/JaoOY7XlUuUyFJkgYzc/K5Y49vOO2IBYpk24wbjlwPXAzcGXgo8F/t10HALr1HJkmSNMXm7QmrqrcDJHkm8ItVtbndfwPw8YUJT5IkaTp1mZh/D+BuI/u7t2WSJEnaRl2WqDgNuCTJBUBoFmo9pc+gJEnS8rDU53Vtjy53R741yQeBQ2gm6j+vqr7ee2SSJElTrNOK+cDBwC/R9II9vOvFk6xJcmWSq5KcPMfx5yS5IslnkpyfZL+u15YkSVrKujzA+zSaVfKvaL9OSvLiDuetAE4HDgdWAccmWTWr2iXA6qp6EHAO8NKtC1+SJGlp6jIn7DHAQVV1C0CSt9MkT3824byDgauq6ur2vLOBo2gSOQCq6oKR+p8Antw9dEmSpKWr63Dk3Ue29+h4zl7A6IO/N7Zl8zke+GDHa0uSJC1pXXrC/oY73h15h/ld2yPJk4HVwKHzHD8BOAFg33333ZEvLUmSNIgud0e+O8mF3DYhv+vdkdcC+4zs792W3U6Sw4DnA4dW1U3zxHAGcAbA6tWr532UkiRJ0lLRdTjyTsAm4NvA/ZM8ssM5FwEHJNk/yS7AMcDa0QpJHgK8ETiyqr7ZOWpJkqQlbmJPWJKXAE8ELgduaYsL+Ni486pqc5ITgfOAFcCZVXV5klOB9VW1FngZzQr870sC8JWqOnJb34wkSdJS0WVO2OOAA+cbKhynqtYB62aVvWBk+7CtvaYkSVIXi301/i7DkVcDO/cdiCRJ0nLSpSfsRuDSJOcDt/aGVdVJvUUlSZKWhMXe27SYdUnC1jJrQr0kSZK2T5clKt6+EIFIkiQtJ12XqJAkSdIOZBImSZI0AJMwSZKkAcybhCU5McnKdvt+ST6W5NtJPpnkZxcuREmSpOkzrifsmVW1qd1+DfCqqro78DzgDX0HJkmSNM3GJWGjd07+RFW9H6CqLgTu2mdQkiRJ025cEnZOkrcluQ/w/iR/mGS/JE8HvrJA8UmSJE2ledcJq6rnJ3ka8G7gvsCuwAnAB4DfWYjgJEmSptXYxVqr6m3A2xYkEkmSpGVkbBKW5GCgquqiJKuANcDnq2rdgkQnSZI0peZNwpK8EDgc2CnJh4FDgAuAk5M8pKpetEAxSpIkTZ1xPWFHAwfRzAX7OrB3VX0nycuBTwImYZIkSdto3N2Rm6vq5qq6EfhiVX0HoKp+ANyyINFJkiRNqXFJ2I+S7NZuP2xLYZI9MAmTJEnaLuOGIx9ZVTcBVNVo0rUzcFyvUUmSJE25ceuE3TRP+SZg01zHJEmS1M244UhJkiT1xCRMkiRpACZhkiRJAzAJkyRJGsDYxxZJkqSlYebkc+c9tuG0I7b53C7na9vYEyZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJA+j17sgka4DXACuAN1fVabOO7wqcRfOA8OuAJ1bVhj5jkqaddzlJS5M/u8tPbz1hSVYApwOHA6uAY5OsmlXteOD6qrof8CrgJX3FI0mStJj02RN2MHBVVV0NkORs4CjgipE6RwGntNvnAK9LkqqqHuOSgMX9V+dijm17bM86RpI0bfqcE7YXcM3I/sa2bM46VbUZuAG4V48xSZIkLQrpq9MpydHAmqp6Rrv/FOCQqjpxpM5lbZ2N7f4X2zqbZl3rBOCEdvdA4Mpegr7NSmDTxFrLm200nu0zmW00nu0zmW00nu0z2UK00X5VtedcB/ocjrwW2Gdkf++2bK46G5PsBOxBM0H/dqrqDOCMnuK8gyTrq2r1Qr3eUmQbjWf7TGYbjWf7TGYbjWf7TDZ0G/U5HHkRcECS/ZPsAhwDrJ1VZy1wXLt9NPAR54NJkqTloLeesKranORE4DyaJSrOrKrLk5wKrK+qtcBbgHckuQr4Fk2iJkmSNPV6XSesqtYB62aVvWBk+4fAE/qMYRst2NDnEmYbjWf7TGYbjWf7TGYbjWf7TDZoG/U2MV+SJEnz87FFkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJA+j1sUV9WLlyZc3MzAwdhiRJ0kQXX3zxpqrac65jSy4Jm5mZYf369UOHIUmSNFGSL893zOFISZKkAZiESZIkDcAkTJIkaQAmYZIkSQMwCZMkSRqASZgkSdIATMIkSZIGYBImSZI0AJMwSZKkAZiESZIkDcAkTJIkaQAmYZIkSQMwCZMkSRqASZgkSdIATMIkSZIGsFVJWJJ7JHlQX8FIkiQtFxOTsCQXJrlbknsCnwLelOSV/YcmSZI0vbr0hO1RVd8BHg+cVVWHAIf1G5YkSdJ065KE7ZTkp4HfBv6p53gkSZKWhS5J2KnAecAXq+qiJPcB/qvfsCRJkqbbTpMqVNX7gPeN7F8N/FafQUmSJE27LhPz75/k/CSXtfsPSvLn/YcmSZI0vboMR74J+FPgxwBV9RngmD6DkiRJmnZdkrDdquo/Z5Vt7iMYSZKk5aJLErYpyX2BAkhyNPC1XqOSJEmachMn5gN/AJwB/EySa4EvAU/uNSpJkqQp1+XuyKuBw5LcBbhTVX23/7AkSZKm27xJWJLnzFMOQFX56CJJkqRtNK4n7K7tvwcCDwfWtvu/AcyeqC9JkqStMG8SVlV/CZDkY8BDtwxDJjkFOHdBopMkSZpSXe6O/EngRyP7P2rLJEmStI263B15FvCfSd4PBDgKeFufQUmSJE27LndHvijJB4Ffolkr7OlVdUnvkUmSJE2xLsORADcDt4x8dZJkTZIrk1yV5OQ5jj8nyRVJPtM+n3K/rteWJElayro8wPvZwN8BK4GfAN6Z5FkdzlsBnA4cDqwCjk2yala1S4DVVfUg4BzgpVsXviRJ0tLUZU7Y8cAhVfV9gCQvAf4DeO2E8w4GrmoXeyXJ2TTzya7YUqGqLhip/wlciV+SJC0TXYYjQzMcucXNbdkkewHXjOxvbMvmczzwwQ7XlSRJWvK69IS9Ffhke3ckwOOAt+zIIJI8GVgNHDrP8ROAEwD23XffHfnSkiRpCZk5efJSpRtOO2IBItl+Xe6OfGWSjwK/0BZ1vTvyWmCfkf2927LbSXIY8Hzg0Kq6aZ4YzqB5iDirV6+uDq8tSZK0qHXpCQO4FPjalvpJ9q2qr0w45yLggCT70yRfxwBPGq2Q5CHAG4E1VfXNrYhbkiRpSZuYhLV3Qr4Q+Aa3zQcr4EHjzquqzUlOBM4DVgBnVtXlSU4F1lfVWuBlwO7A+9oHg3+lqo7cjvcjSZK0JHTpCXs2cGBVXbe1F6+qdcC6WWUvGNk+bGuvKUmSNA263B15DXBD34FIkiQtJ116wq4GLkxyLnDrxPmqemVvUUmSJE25LknYV9qvXdovSZIkbacuS1T85UIEIkmStJx0fYC3JEmSdqCu64RJkiTdQZcV7GHprGK/kOwJkyRJGsC8PWFJdqJ5qPZvAvdui68F/h/wlqr6cf/hSZIkTadxw5HvAL4NnAJsbMv2Bo4D3gk8sc/AJEmSptm4JOxhVXX/WWUbgU8k+UKPMUmSJE29cUnYt5I8Afj7qroFIMmdgCcA1y9EcJIkafnoOsl/R11n6JsFxk3MPwY4GvhGki+0vV/fAB7fHpMkSdI2mrcnrKo20M77SnKvtmyrH+ItSZKkO+q0REVVXVdV1yU5q++AJEmSloNxS1SsnV0E/HKSuwNU1ZE9xiVJkjTVxk3M3xu4AngzUDRJ2GrgFQsQlyRJ0lQbNxy5GrgYeD5wQ1VdCPygqj5aVR9diOAkSZKm1biJ+bcAr0ryvvbfb4yrL0mSpO4mJlVVtRF4QpIjgO/0H5IkSdL069yzVVXnAjtmFTVJkqRlrtMSFZIkSdqxTMIkSZIGYBImSZI0AJMwSZKkAZiESZIkDcAkTJIkaQAmYZIkSQMwCZMkSRqAjyGSdDszJ++YNZk3nHbEDnutLteS1NiRP1c76v8Dzc2eMEmSpAH02hOWZA3wGmAF8OaqOm3W8V2Bs4CHAdcBT6yqDX3GJI2zkH/1LXTvzkL/RbsY/4K2501L3WL8udK2660nLMkK4HTgcGAVcGySVbOqHQ9cX1X3A14FvKSveCRJkhaTPnvCDgauqqqrAZKcDRwFXDFS5yjglHb7HOB1SVJV1WNcU6XLX0X+Vb84/3pcjDEtVovxc77QMS3GNliMFrq3c0f+HC/Gz7D61eecsL2Aa0b2N7Zlc9apqs3ADcC9eoxJkiRpUUhfnU5JjgbWVNUz2v2nAIdU1YkjdS5r62xs97/Y1tk061onACe0uwcCV/YS9G1WApsm1lrebKPxbJ/JbKPxbJ/JbKPxbJ/JFqKN9quqPec60Odw5LXAPiP7e7dlc9XZmGQnYA+aCfq3U1VnAGf0FOcdJFlfVasX6vWWIttoPNtnMttoPNtnMttoPNtnsqHbqM/hyIuAA5Lsn2QX4Bhg7aw6a4Hj2u2jgY84H0ySJC0HvfWEVdXmJCcC59EsUXFmVV2e5FRgfVWtBd4CvCPJVcC3aBI1SZKkqdfrOmFVtQ5YN6vsBSPbPwSe0GcM22jBhj6XMNtoPNtnMttoPNtnMttoPNtnskHbqLeJ+ZIkSZqfjy2SJEkawLJOwpKsSXJlkquSnDzH8d9P8tkklyb51zlW/J96k9popN5vJakky+pOnA6foacl+e/2M3RpkmcMEeeQunyGkvx2kiuSXJ7kXQsd45A6fIZeNfL5+UKSbw8Q5qA6tNG+SS5IckmSzyR5zBBxDqVD++yX5Py2bS5MsvcQcQ4lyZlJvtkuizXX8ST527b9PpPkoQsWXFUtyy+amwW+CNwH2AX4NLBqVp27jWwfCXxo6LgXWxu19e4KfAz4BLB66LgXU/sATwNeN3Ssi7yNDgAuAe7R7v/E0HEvpvaZVf9ZNDc5DR77Ymojmnk9z2y3VwEbho57kbXP+4Dj2u1HA+8YOu4FbqNHAg8FLpvn+GOADwIBfg745ELFtpx7wm59rFJV/QjY8lilW1XVd0Z27wIstwl0E9uo9Vc0z/384UIGtwh0bZ/lrEsb/S5welVdD1BV31zgGIe0tZ+hY4F3L0hki0eXNirgbu32HsBXFzC+oXVpn1XAR9rtC+Y4PtWq6mM0KzDM5yjgrGp8Arh7kp9eiNiWcxLW5bFKJPmDdiX/lwInLVBsi8XENmq7bfepquX4ELJOnyHgt9ou7nOS7DPH8WnWpY3uD9w/yb8l+USSNQsW3fC6foZIsh+wP7f9Ml0uurTRKcCTk2ykuSP/WQsT2qLQpX0+DTy+3f5N4K5JfETgbTr/HO5oyzkJ66SqTq+q+wLPA/586HgWkyR3Al4J/PHQsSxi/wjMVNWDgA8Dbx84nsVoJ5ohyUfR9PS8KcndhwxokToGOKeqbh46kEXoWOBtVbU3zdDSO9r/n9T4E+DQJJcAh9I8rcbP0SKwnD+kXR6rNOps4HF9BrQITWqjuwIPBC5MsoFmLH3tMpqcP/EzVFXXVdVN7e6bgYctUGyLRZefs43A2qr6cVV9CfgCTVK2HGzN/0PHsPyGIqFbGx0PvBegqv4DuDPNMwGXgy7/D321qh5fVQ8Bnt+WfXvBIlz8tjYf2GGWcxI28bFKSUZ/ERwB/NcCxrcYjG2jqrqhqlZW1UxVzdBMzD+yqtYPE+6C6/IZGp1XcCTwuQWMbzHo8viyD9D0gpFkJc3w5NULGOOQurQPSX4GuAfwHwsc32LQpY2+AvwKQJL/SZOE/feCRjmcLv8PrRzpGfxT4MwFjnGxWws8tb1L8ueAG6rqawvxwr2umL+YVbfHKp2Y5DDgx8D13Pacy2WhYxstWx3b56QkRwKbaSaGPm2wgAfQsY3OA34tyRU0QyTPrarrhot64WzFz9gxwNnV3sq1nHRsoz+mGcb+I5pJ+k9bLm3VsX0eBfxNkqK5k/0PBgt4AEneTdMGK9t5gy8EdgaoqjfQzCN8DHAVcCPw9AWLbZl8TiVJkhaV5TwcKUmSNBiTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTtN2SPC5JtetZDRXDvZOcs4Ou9bgkq0b2T22Xq9ne6z4qyQ1JLk3y+SQvHyoWScMzCZO0IxwL/Gv77w6RZKvWMWxXBT96B73842geerzl2i+oqn/ZQdf+eFUdBDwEeGySXxgwFkkDMgmTtF2S7A78Is2jY44ZKX9Uko8lOTfJlUnesGXV7iTfS/KqJJcnOT/Jnm35hUlenWQ98Owkv5LkkiSfTXJmkl2TPLx9IPqdk9ylvcYDk8wkuay9ztOSfCDJh5NsSHJikue01/pEknu29X43yUVJPp3k75PsluTnaZ5u8LK2x+q+Sd6W5Oj2nDvE1JZvSPKXST7VHhvbK1hVPwAupX1Q8I6MRdLSYBImaXsdBXyoqr4AXJdk9PmYBwPPounJuS/w+Lb8LjSreT8A+CjNCtZb7FJVq4HTgbcBT6yqn6V5wsczq+oimseM/DXwUuCdVXXZHHE9sH29hwMvAm5sn533H8BT2zr/UFUPr6oH0zxS6viq+vf2+s+tqoOq6otbLpjkznPFNPKam6rqocD/pXlo8ryS3IPmGZkf6ykWSYucSZik7XUszQPuaf8dHZL8z6q6uqpupnn49C+25bcA72m33zlSzkj5gcCX2uQO4O3AI9vtU4FfBVbTJGJzuaCqvltV/w3cAPxjW/5ZYKbdfmCSjyf5LPA7wAMmvNdxMQH8Q/vvxSOvMdsvJfk0zQOCz6uqr/cUi6RFbtk+O1LS9muH9R4N/Gz7XLoVQCV5bltl9nPR5ntO2mj59zu89L2A3Wme/3bnec65aWT7lpH9W7jt/763AY+rqk8neRrtg8S3w5bXuJn5/3/9eFU9Nsn+wCeSvLeqLu0hFkmLnD1hkrbH0cA7qmq/qpqpqn2ALwG/1B4/OMn+7VywJ9JM3ofm/54tk+ifNFI+6kpgJsn92v2n0AxdArwR+Avg74CXbEf8dwW+lmRnmt6nLb7bHtuamLZKVX0JOA143tCxSBqGSZik7XEs8P5ZZX/PbUOSFwGvo5nj9KWRut+nSdAuo+lJO3X2havqh8DTgfe1Q3S3AG9I8lTgx1X1Lpok5uFJHr2N8f8F8Eng34DPj5SfDTy3nfR+30kxbeNr0577yCQziyAWSQssVfONDkjStkvyKOBPquqxcxz7XlXtvuBBSdIiYk+YJEnSAOwJkyRJGoA9YZIkSQMwCZMkSRqASZgkSdIATMIkSZIGYBImSZI0AJMwSZKkAfx/V3nRNtBShWoAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 720x720 with 6 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, axes = plt.subplots(len(NUM_NODES_LIST), sharex=True, sharey=True)\n",
+    "\n",
+    "fig.set_size_inches(10, 10)\n",
+    "\n",
+    "for i, num_nodes in enumerate(NUM_NODES_LIST):\n",
+    "    axes[i].hist(pauli_rounding_approximation_ratios[num_nodes], weights=np.zeros_like(pauli_rounding_approximation_ratios[num_nodes]) + 1./TRIALS, bins=50)\n",
+    "    axes[i].set_ylabel(f\"{num_nodes} nodes\")\n",
+    "\n",
+    "fig.suptitle(\"QRAO (Pauli Rounding) MaxCut Performance\")\n",
+    "plt.xlabel(\"Approximation Ratio\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bf221b56aca547b1afa8287315c7f85b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "58f8c1989057442288aab1342e5a10b0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e9c43406ae874fd487b78f61df73e225",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eb9dc76ff66a4e87bf2f8cd59789559e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "107b2b8468544be89535b3d80f8916b7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bb4cdcc7845a43ac886c3f4d72ba3652",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "magic_rounding_approximation_ratios = { num_nodes : [ compute_approximation_ratio(num_nodes, magic_rounding) for _ in tqdm(range(TRIALS)) ] for num_nodes in NUM_NODES_LIST }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And here we can see the approximation ratio distribution for using **QRAO with magic rounding** to solve 100 random 3-regular graph MaxCut instances for different graph sizes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmEAAAKVCAYAAACH9jxEAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAABDIklEQVR4nO3de5glVXnv8e9PLhJF8TIkUW6NiCSYKOoIaoyYiAmKgjEYAS/og+HEI2Ji4pFoYgwnJqhRkxiMkqgoXlCJ5owCGoOgJhGkEbyAYkZEGbwOCl5QEHjPH1Uj26Z775qZrq7u3d/P8/QzVavWrnr36t3d76y1alWqCkmSJC2t2w0dgCRJ0mpkEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJk5ZAkn2TzCbJEl7zRUn+Zamut9iSPDLJhpH9S5M8chHOe78k/72151ltkvxOkquS/CDJA4aOR5oGJmGaKkmekeSzSa5P8o0kr0uy08jxlyb5SfuH5Nok/53kofOc59QkNyW5xzzHHpfkk0l+mOSaJG9PsuuE0P4v8LfVLsyX5MokNyZZM+fcFyepJDNb1AAjquqvq+pZm/u6JOcl+XHbRhuTvHe+dlhqVXXfqjpvEc7zGeDaJI9fqE7bBpXk/nPK39eWP3Jr42jPd1SbnP8gydeTnJ3k4R1fe2WSg8Ycf2SSW9pzfz/J5UmeuRXh/i1wXFXtWFUXb8V5JLVMwjQ1kvwx8HLgBcBOwEOAGeDfk2w3UvVdVbUjsAY4F3jPnPPcEfhd4DrgqXOOHQ68A/i79vX3BW4A/jPJXReI6x7AbwD/NufQl4EjR+r9KnCHjm+3b8e1bXRvYEeaP8DT5O3A/5pQ54vA0zftJLk78FDg24sRQJLn03yO/hr4BWB34HXAYYtx/tbX2u/jnYEXAv+cZN/NjHPbdnMP4NItCSLJNlvyOmnamYRpKiS5M/CXwHOr6oNV9ZOquhL4PeBewFFzX1NVN9H8Md4lyc4jh34XuBY4ETh65BoBXgX8VVW9o6p+VFXfAJ4F/AD4owXCezTwqar68Zzy0xj5I99e661z3tchbe/Y99qhoJfOOf70JF9pe+T+fLR3pO31e9tI3Ye3PX/Xtud6xgLx/lRVXUuTPO43cp6HJbkwyXXtvw8bOfYzvTOjMSSZaXuRjk7y1baX7cUjdX+u7YH8bpLLgAfPea9z39u7k7y17eW5NMnakboPbNvt+0nek+RdSf5q5HTnAY9Kcvsxb//twJNHEogjgfcBN45cZ/8kn2jb9OtJ/jHJ9iPttDHJbu3+/dv39ktpemdPBJ5TVe+tqh+2n9n3V9UL2vqnjsackeHZJKfRJG3vb3u6/s+Y90E1/g34LrBvktslOSHJl9rPzruT3G3O9+mYJF8FPp7kB8A2wKeTfKmt98ttj+G1bfsfOhLrqUn+KclZSX4I/Eb7/XtBks+k6UV+Y5JfSNP79/0k/zH6H5n2+/aN9nP2sST3nXP+k5Oc2b72giR7jRy/b5IPJ/lOkm8meVFbvuD7loZgEqZp8TBgB+C9o4VV9QPgLOC35r6g/WP5dOAamj9OmxwNvBM4HfilJA9qy/eh+cP3Mz1nVXUL8K80ydZ8fhW4fJ7y84E7t3/MtgGOAN42p84P2xjvAhwCPDvJE9r496XpOXkKcA+a3r9d5gsgyR7A2cBrgZ1pkqpLFoh39HV3B54IrG/37wacCfwDcHfg1cCZbb2uHk7Tlo8CXpLkl9vyvwD2ar9+m5EEeAGH0nyP7gKsA/6xjXF7mmTpVOBuNN/L3xl9YVVdDfykjWMhXwMu49bPztOZkyQDN9Mk32toeskeBfzv9hr/DbwBeEuSn6P53v55VX2hrbtDG+dmq6qnAV8FHt8OD75iXP02+fgdmrb6LPBc4AnAgcA9aT7/J8952YHALwO/2famAdy/qvZK07P8fuDfgZ9vz/f2JKPteRTwMuBOwH+2Zb9L83NyH+DxNJ/JF9F8Jm8HHD/y+rOBvdvzf4omKR51BM1/vO5K8/l8Wfte7wT8B/DB9r3dGzinfU2X9y0tGZMwTYs1wMa2d2uur9P8kt/k95JcC/wI+H3g8E2vS7I7zdDhO6rqmzS/vDf1Vq0ZOd9811gzTzk0f/i+v8CxTb1hjwY+D1w9erCqzquqz1bVLe1cpnfS/AEBOBx4f1X9Z1XdCLwEWOhhsEcB/1FV72x7XK6pqksWqAvwD0muAza27+u5bfkhwP9U1WlVdVNVvRP4As0f1K7+su1F/DTwaWDTvKvfA15WVd+pqqtoEr1x/rOqzqqqm2nacdN5HgJsC/xD+17fC3xyntd/n+Z7M85bgacn+SXgLlX1idGDVXVRVZ3ftsWVNEnXgSNVXkqTHH+S5nu76Q/+3Vn487qY7tl+1jfSJLlPq6rLgT8AXlxVG6rqhjbOw3Pr0CPAS9seuh/Nc96H0AxTn1RVN1bVR4APMDK8Dvy/qvqv9rO7qRf4tVX1zTYJ/jhwQVVd3B5/H/DTCf9V9aaq+v5IfPfPyPxO4H1V9cmRHu392vLHAd+oqldV1Y/bc1zQHuvyvqUlYxKmabERWLPAL9N7tMc3eXdV3YVmHs7ngAeNHHsa8PmRBOXtwFHt//w3nWO+SepzrzHquzS9AfM5jSZBega37WUhyQFJzk3y7TYp+gNuTfbuCVy1qW5VXU/Tqzef3YAvLXBsPsdX1U7A/Wh6GjbdeHBP4Ctz6n6FBXrgFvCNke3raf6Ybzr3VSPH5l5n0nl2aL//9wSu3nQTROsqbutONMPO47wX+E3gOJrv1c9Icp8kH2iHzb5HM7/rp8l4Vf2EpkfuV4BXjcR0DQt/XhfT16rqLlV1t6rar6pOb8v3AN7XDiVeS/MfgJtpfiY2ma/NNrkncFXbC7zJ3M/BfK//5sj2j+bZ3xGaOWRJTmqHDb8HXNnWGf2PzkKfo3Gf9S7vW1oyJmGaFp+gmSD/xNHCJDsCj6GZA/QzqmojcCzw0tx699/TgXu1f1S/QTPctgZ4LM2Q4gbgSXOucTuaYZZzmN9naIZfbqOqvkIzQf+xzBlKbb2DZqhttzYpej2waZmLr3NrckQ75LXQsOBVNMN8m6WqPgv8FXByktAM0e0xp9ru3NqD90N+9uaCX9yMy32d5g/o6Hm3xNdp5vmNLgcyel6S7AJsz/zDxD/VJrZnA89mniQM+CeansC9q+rONENrP71ue52/AN4MvCq3zkHb9Hl9wpjLT2rLhXo9u7gKeEyboG362qHtoepy/q8Bu7Wf/U1GPwdbG99RNDcoHETTkzjTlndZ4uUqmnmgCx2b9L6lJWMSpqlQVdfRzA95bZKDk2yXZpmHd9P0UM2dT7LpdZcDHwL+T5qlKvYC9qcZ2tiPpgfjHcDT216MPwH+LM3SAjsk+UXgX2juPnvNAuF9GHhgkh0WOH4MzbybH85z7E7Ad6rqx0n252dvMDgDeHyaCeDb0wytLPRH6u3AQUl+L8m2Se6eZL8F6s71FpqegkNp5tfdp33/2yZ5MrAvzVAUNPPMjmjbfy3NkGlX7wb+NMld0yz58dxJL1jAJ2h6N45rYzyM5ns66kDgI+2Q1CQvAg5shxvnuhPwPeAH7ZDlszcdaJPAU4E30nyPv06zVMmmz+tLaJLbJyS5Q9tmj0myaX7XJcBjk9yt/Zz94Zxrf5OFk41JXg+8rJ0rSJKd23bq6gKa3qf/08b9SJoh6dPHvWgz3IkmSb2GJhH968147QeAeyT5wyS3T3KnJAe0x7b2fUuLyiRMU6OdnPwimuUUvk/Tw3QH4KAFEpxNXknTI/b7NPNYPltV39j0Bfw98Lgkd6uqd9EMWf4RzR+Iy4CfA36tquYdCmznln2EBZYeqKovVdXsArH9b+DEJN+n+aP97pHXXUqTqJxO8wf+B8C3aP54zb3GV2l62/4Y+A7NH/j7z623QHw30rTBn7fv8XHtea4B/g/wuLZXEeDPaRLZ79Ikxe/oco3WX9IMaX2ZZsL3fD1PXeN9Ik3icy3NMiMf4Gfb5Sk0f5C7nO9rVfWfCxz+E5rE+PvAPwPvGjl2PM2k8j9vE/hnAs9M8uvteV8FPB/4M5plL66iGfb8t/b1p9HMmbuSpj1Gzw3wNzT/Ibg2yZ90eS8j/p6mh/Xf28/W+cAB419yq7aNH0/Ty7yR5gaRp7c3HSyGt9J8Fq6m+Rk7fzNi+z7NHMvH0wxZ/g/NPE/YyvctLbb87LQJaXqkWZjyRJoE6asDx7IvTY/S/tXTD1079HotzdDYl/u4xkqV5ALg9VX15iT3A95QVbdZpFeSlpJJmKZakqcBPxmZkDxV0qz6fg7NMOSraP5X/8C+Er2VIsmBNPO9NnJrr9e9qmq+O1slaRDelqupVlVbNKS1ghxGM2wVYBY4YrUnYK19aIZu7whcQbMMiQmYpGXFnjBJkqQBODFfkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJA9h26AA215o1a2pmZmboMCRJkia66KKLNlbVzvMdW3FJ2MzMDLOzs0OHIUmSNFGSryx0zOFISZKkAZiESZIkDWDFDUdK0rSZOeHMTvWuPOmQniORtJTsCZMkSRqASZgkSdIATMIkSZIGYBImSZI0AJMwSZKkAZiESZIkDcAkTJIkaQAmYZIkSQMwCZMkSRqASZgkSdIATMIkSZIGYBImSZI0AB/gLal3XR9QDT6kWtLqYU+YJEnSAEzCJEmSBmASJkmSNICJSViSVyS5c5LtkpyT5NtJnroUwUmSJE2rLj1hv1VV3wMeB1wJ3Bt4QZ9BSZIkTbsuSdimOygPAd5TVdd1PXmSg5NcnmR9khPmOf78JJcl+Uzby7ZH13NLkiStZF2SsA8k+QLwIOCcJDsDP570oiTbACcDjwH2BY5Msu+cahcDa6vqfsAZwCs2J3hJkqSVamISVlUnAA+jSZZ+AlwPHNbh3PsD66vqiqq6ETh97uuq6tyqur7dPR/YdXOClyRJWqm6TMy/A/C/gX9qi+4JrO1w7l2Aq0b2N7RlCzkGOLvDeSVJkla8LsORbwZupOkNA7ga+KvFDKK923It8MoFjh+bZDbJ7Le//e3FvLQkSdIguiRhe1XVK4CfALTDh+nwuquB3Ub2d23LfkaSg4AXA4dW1Q3znaiqTqmqtVW1duedd+5waUmSpOWtSxJ2Y5KfAwogyV7AvMnSHBcCeyfZM8n2wBHAutEKSR4AvIEmAfvWZkUuSZK0gnV5gPdfAB8EdkvyduDXgGdMelFV3ZTkOOBDwDbAm6rq0iQnArNVtY5m+HFH4D1JAL5aVYdu0TuRJElaQSYmYVX14SSfAh5CMwz5vKra2OXkVXUWcNacspeMbB+0eeFKkiRNhwWTsCQPnFP09fbf3ZPsXlWf6i8sSZKk6TauJ+xV7b870Ny5+GmanrD7AbPAQ/sNTZIkaXotODG/qn6jqn6Dpgfsge3diQ8CHsA8dzlKkiSpuy53R+5TVZ/dtFNVnwN+ub+QJEmSpl+XuyM/k+RfgLe1+08BPtNfSJIkSdOvSxL2TODZwPPa/Y9x6yOMJLVmTjizc90rTzqkx0gkSStBlyUqfpzkZOA/aBZsvbx9kLckSZK20MQkLMkjgbcAV9LcHblbkqOr6mO9RiZJkjTFugxHvgr4raq6HCDJfYB3Ag/qMzBJkqRp1uXuyO02JWAAVfVFYLv+QpIkSZp+XXrCZue5O3K2v5AkSZKmX5ck7NnAc4Dj2/2PA6/rLSJJkqRVoMvdkTcAr26/JEmStAi63B35a8BLgT1G61fVvfoLS5Ikabp1GY58I/BHwEXAzf2GI0mStDp0ScKuq6qze49EkiRpFemShJ2b5JXAe4EbNhVW1ad6i0qSJGnKdUnCDmj/XTtSVsBvLn44kiRJq0OXuyN/YykCkSRJWk26rJgvSZKkRdZlOFKSpEHMnHBmp3pXnnRIz5FIi8+eMEmSpAEs2BOWZHvgCOBrVfUfSY4CHgZ8Hjilqn6yRDFKkiRNnXHDkW9uj98hydHAjjTLVDwK2B84uv/wJEmSNs9KGcYel4T9alXdL8m2wNXAPavq5iRvAz69NOFJkiRNp3Fzwm7XDkneCbgDsFNbfntgu74DkyRJmmbjesLeCHwB2AZ4MfCeJFcADwFOX4LYJEmSptaCSVhVvSbJu9rtryV5K3AQ8M9V9cmlClCSJGkajV0nrKq+NrJ9LXBG3wFJkiStBq4TJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAPsBbm6XrKsQw/ErEkiQtZ/aESZIkDcAkTJIkaQAmYZIkSQMwCZMkSRqASZgkSdIATMIkSZIGYBImSZI0ANcJU2+6rinmemKStPn8Hbvy9doTluTgJJcnWZ/khHmO3z7Ju9rjFySZ6TMeSZKk5aK3nrAk2wAnA48GNgAXJllXVZeNVDsG+G5V3TvJEcDLgSf3FVNXrgovdbM5PyvTwt4HSYulz56w/YH1VXVFVd0InA4cNqfOYcBb2u0zgEclSY8xSZIkLQt9JmG7AFeN7G9oy+atU1U3AdcBd+8xJkmSpGUhVdXPiZPDgYOr6lnt/tOAA6rquJE6n2vrbGj3v9TW2TjnXMcCx7a7+wCX9xL0rdYAGyfWWt1so/Fsn8lso/Fsn8lso/Fsn8mWoo32qKqd5zvQ592RVwO7jezv2pbNV2dDkm2BnYBr5p6oqk4BTukpzttIMltVa5fqeiuRbTSe7TOZbTSe7TOZbTSe7TPZ0G3U53DkhcDeSfZMsj1wBLBuTp11wNHt9uHAR6qvrjlJkqRlpLeesKq6KclxwIeAbYA3VdWlSU4EZqtqHfBG4LQk64Hv0CRqkiRJU6/XxVqr6izgrDllLxnZ/jHwpD5j2EJLNvS5gtlG49k+k9lG49k+k9lG49k+kw3aRr1NzJckSdLCfHakJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkagEmYJEnSAHp9bFEf1qxZUzMzM0OHIUmSNNFFF120sap2nu/YikvCZmZmmJ2dHToMSZKkiZJ8ZaFjDkdKkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjSAiUlYkr2S3L7dfmSS45PcpffIJEmSpliXnrB/BW5Ocm/gFGA34B29RiVJkjTluiRht1TVTcDvAK+tqhcA9+g3LEmSpOnWJQn7SZIjgaOBD7Rl2/UXkiRJ0vTrkoQ9E3go8LKq+nKSPYHT+g1LkiRpum07qUJVXZbkhcDu7f6XgZf3HZgkSdI063J35OOBS4APtvv7JVnX5eRJDk5yeZL1SU6Y5/jzk1yW5DNJzkmyx2bGL0mStCJ1GY58KbA/cC1AVV0C3GvSi5JsA5wMPAbYFzgyyb5zql0MrK2q+wFnAK/oGLckSdKK1mliflVdN6fslg6v2x9YX1VXVNWNwOnAYaMVqurcqrq+3T0f2LXDeSVJkla8LknYpUmOArZJsneS1wL/3eF1uwBXjexvaMsWcgxwdofzSpIkrXhdkrDnAvcFbgDeCXwP+MPFDCLJU4G1wCsXOH5sktkks9/+9rcX89KSJEmD6HJ35PXAi9uvzXE1zer6m+zalv2MJAe15z6wqm5YIIZTaFbrZ+3atbWZcUiSJC07CyZhSd4PLJjwVNWhE859IbB3u67Y1cARwFFzrvEA4A3AwVX1ra5BS5IkrXTjesL+tv33icAvAm9r948EvjnpxFV1U5LjgA8B2wBvqqpLk5wIzFbVOprhxx2B9yQB+GqH5E6SJGnFS9X40b0ks1W1dlLZUlm7dm3Nzs4OcWlJkqTNkuSihXKmLhPz75jkp+uCtcOLd1ys4CRJklajiRPzgT8CzktyBRBgD+DYXqOSJEmacl3ujvxgkr2BX2qLvrDQXYySJEnqZmISlmQ74H8Bj2iLzkvyhqr6Sa+RSZIkTbEuw5H/BGwHvK7df1pb9qy+gpIkSZp2XZKwB1fV/Uf2P5Lk030FJEmStBp0uTvy5iR7bdpp75S8ub+QJEmSpl+XnrAXAOfOuTvymb1GJUmSNOW63B15Tnt35D5t0eXeHSlJkrR1uvSEATwImGnr75eEqnprb1FJkiRNuS5LVJwG7AVcwq1zwQowCZMkSdpCXXrC1gL71qSHTEqSJKmzLndHfg74xb4DkSRJWk269IStAS5L8kngpxPyq+rQ3qKStMVmTjhzYp0rTzpkCSKRJI3TJQl7ad9BSJIkrTZdlqj46FIEIkmStJp0mRMmSZKkRWYSJkmSNIDNSsKS3L2vQCRJklaTBZOwJCclWdNur22fHXlBkq8kOXDJIpQkSZpC43rCDqmqje32K4EnV9W9gUcDr+o9MkmSpCk2LgnbNsmmuyd/rqouBKiqLwK37z0ySZKkKTYuCXsdcFaS3wQ+mOTvkxyY5C9pniMpSZKkLbTgOmFV9doknwWeDdynrbs38G/AXy1JdJK0SnR50gH4tANpmoxdrLWqzgPOW5JIJEmSVpEtWicsyTMXOxBJkqTVpMuzI+fzl8CbFzMQSVoMPsBc0kqxYBKW5DMLHQJ+oZ9wJEmSVodxPWG/APw28N055QH+u7eIJGkBXSevS9JKMC4J+wCwY1VdMvdAkvP6CkiSJGk1GLdExTFjjh3VTziSJEmrw5ZOzJc05ZzgbhtI6tcWLVEhSZKkrWNPmCRpqvj0Aa0U9oRJkiQNwCRMkiRpAA5HSlvBiduaZn6+pX7ZEyZJkjQAe8KkZWCl9jgs5gr2y/H9dbHU37vFavOlbu/Faqfl+NSElfrzq+HZEyZJkjQAkzBJkqQBOBwpSdpiy3F4UFopeu0JS3JwksuTrE9ywjzHb5/kXe3xC5LM9BmPJEnSctFbT1iSbYCTgUcDG4ALk6yrqstGqh0DfLeq7p3kCODlwJP7imk1WMoJoot5reX4v2kn0mqxLMfPt6bbar9ZYKU8NaHPnrD9gfVVdUVV3QicDhw2p85hwFva7TOARyVJjzFJkiQtC30mYbsAV43sb2jL5q1TVTcB1wF37zEmSZKkZSFV1c+Jk8OBg6vqWe3+04ADquq4kTqfa+tsaPe/1NbZOOdcxwLHtrv7AJf3EvSt1gAbJ9Za3Wyj8WyfyWyj8WyfyWyj8WyfyZaijfaoqp3nO9Dn3ZFXA7uN7O/als1XZ0OSbYGdgGvmnqiqTgFO6SnO20gyW1Vrl+p6K5FtNJ7tM5ltNJ7tM5ltNJ7tM9nQbdTncOSFwN5J9kyyPXAEsG5OnXXA0e324cBHqq+uOUmSpGWkt56wqropyXHAh4BtgDdV1aVJTgRmq2od8EbgtCTrge/QJGqSJElTr9fFWqvqLOCsOWUvGdn+MfCkPmPYQks29LmC2Ubj2T6T2Ubj2T6T2Ubj2T6TDdpGvU3MlyRJ0sJ8dqQkSdIATMIkSZIGYBImSZI0AJMwSZKkAZiESZIkDcAkTJIkaQAmYZIkSQMwCZMkSRqASZgkSdIATMIkSZIG0OuzI/uwZs2ampmZGToMSZKkiS666KKNVbXzfMdWXBI2MzPD7Ozs0GFIkiRNlOQrCx1zOFKSJGkAJmGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNICJSViSOya5Xbt9nySHJtmu/9AkSZKmV5eesI8BOyTZBfh34GnAqX0GJUmSNO26JGGpquuBJwKvq6onAfftNyxJkqTp1ikJS/JQ4CnAmW3ZNv2FJEmSNP26JGF/CPwp8L6qujTJvYBze41KkiRpym07qUJVfRT4aJI7tPtXAMf3HZgkSdI063J35EOTXAZ8od2/f5LXdTl5koOTXJ5kfZIT5jn+/CSXJflMknOS7LHZ70CSJGkF6jIc+XfAbwPXAFTVp4FHTHpRkm2Ak4HHAPsCRybZd061i4G1VXU/4AzgFZ0jlyRJWsE6LdZaVVfNKbq5w8v2B9ZX1RVVdSNwOnDYnPOe2955CXA+sGuXeCRJkla6LknYVUkeBlSS7ZL8CfD5Dq/bBRhN3ja0ZQs5Bji7w3klSZJWvIkT84E/AP6eJoG6mmbB1ucsZhBJngqsBQ5c4PixwLEAu++++2JeWpIkaRBd7o7cSLNG2Oa6GthtZH/XtuxnJDkIeDFwYFXdsEAMpwCnAKxdu7a2IBZJkqRlZcEkLMlrgQUTnqqatEzFhcDeSfakSb6OAI6ac40HAG8ADq6qb3UNWpIkaaUbNydsFrgI2AF4IPA/7dd+wPaTTlxVNwHHAR+imUP27nax1xOTHNpWeyWwI/CeJJckWbelb0SSJGklSdX40b0k5wMPb5MqkmwHfLyqHrIE8d3G2rVra3Z2dohLS5IkbZYkF1XV2vmOdbk78q7AnUf2d2zLJEmStIW63B15EnBxknOB0CzU+tI+g5IkSZp2Xe6OfHOSs4EDaCbqv7CqvtF7ZJIkSVOsS08YNKvf/3q7XcD7+wlHkiRpdejyAO+TgOcBl7Vfxyf5674DkyRJmmZdesIeC+xXVbcAJHkLzYO3X9RnYJIkSdOs0wO8gbuMbO/UQxySJEmrSpeesL/htndHntBrVJIkSVOuy92R70xyHvDgtsi7IyVJkrZS1+HI2wEbgWuB+yR5RG8RSZIkrQITe8KSvBx4MnApcEtbXMDHeoxLkiRpqnWZE/YEYJ+quqHnWCRJklaNLsORVwDb9R2IJEnSatKlJ+x64JIk5wA/7Q2rquN7i0qSJGnKdUnC1rVfkiRJWiRdlqh4y1IEIkmStJp0XaJCkiRJi8gkTJIkaQCblYQl+fm+ApEkSVpNFpwTluRuc4uATyZ5AJCq+k6vkUmSJE2xcRPzNwJfmVO2C/ApmhXz79VXUJIkSdNuXBL2AuDRwAuq6rMASb5cVXsuSWSSVpyZE85c8NiVJx2yhJFI0vK34JywqnoV8CzgJUleneROND1gkiRJ2kpjJ+ZX1YaqehJwHvBh4A5LEZQkSdK067JiPlW1LsmHgb16jkeSJGlVGNsTluSXkjwqyY5V9aOq+lxbfvDShCdJkjSdxi1RcTzwHODzwBuTPK+q/l97+K+BDy5BfJK06Ia4gcCbFiTNNW448veBB1XVD5LMAGckmamqv6dZM0ySJElbaFwSdruq+gFAVV2Z5JE0idgemIRJkiRtlXFzwr6ZZL9NO21C9jhgDfCrPcclSZI01cYlYU8HvjFaUFU3VdXTgUf0GpUkSdKUW3A4sqo2jDn2X/2EI0kakjcQSEtn7BIVkiRJ6kenxVolDWs59U6Mi0WS1J09YZIkSQMwCZMkSRqAw5HSApbTEGAfpuH9Lbf3sKVDtX0M8a6U76G0mtkTJkmSNACTMEmSpAE4HCktsuU2RLYSLKc2mzQ06Pdw8y2n76+0nNgTJkmSNAB7wqQlZI/A0ulrPbOVsk7aNMTpz4SmXa89YUkOTnJ5kvVJTpjn+O2TvKs9fkGSmT7jkSRJWi56S8KSbAOcDDwG2Bc4Msm+c6odA3y3qu4NvAZ4eV/xSJIkLSd9DkfuD6yvqisAkpwOHAZcNlLnMOCl7fYZwD8mSVVVj3EtC310wS91t/6WDnc4xCBpa/n7R9Ogz+HIXYCrRvY3tGXz1qmqm4DrgLv3GJMkSdKykL46nZIcDhxcVc9q958GHFBVx43U+VxbZ0O7/6W2zsY55zoWOLbd3Qe4vJegb7UG2Dix1upmG41n+0xmG41n+0xmG41n+0y2FG20R1XtPN+BPocjrwZ2G9nftS2br86GJNsCOwHXzD1RVZ0CnNJTnLeRZLaq1i7V9VYi22g822cy22g822cy22g822eyoduoz+HIC4G9k+yZZHvgCGDdnDrrgKPb7cOBj6yG+WCSJEm99YRV1U1JjgM+BGwDvKmqLk1yIjBbVeuANwKnJVkPfIcmUZMkSZp6vS7WWlVnAWfNKXvJyPaPgSf1GcMWWrKhzxXMNhrP9pnMNhrP9pnMNhrP9pls0DbqbWK+JEmSFuazIyVJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjSAXp8d2Yc1a9bUzMzM0GFIkiRNdNFFF22sqp3nO7bikrCZmRlmZ2eHDkOSJGmiJF9Z6JjDkZIkSQMwCZMkSRqASZgkSdIATMIkSZIGYBImSZI0AJMwSZKkAZiESZIkDcAkTJIkaQAmYZIkSQMwCZMkSRqASZgkSdIATMIkSZIGYBImSZI0AJMwSZKkAZiESZIkDWBiEpbkjklu127fJ8mhSbbrPzRJkqTp1aUn7GPADkl2Af4deBpwap9BSZIkTbsuSViq6nrgicDrqupJwH37DUuSJGm6dUrCkjwUeApwZlu2TX8hSZIkTb8uSdgfAn8KvK+qLk1yL+DcXqOSJEmachOTsKr6aFUdCry23b+iqo7vcvIkBye5PMn6JCfMc/z5SS5L8pkk5yTZY7PfgSRJ0grU5e7Ihya5DPhCu3//JK/r8LptgJOBxwD7Akcm2XdOtYuBtVV1P+AM4BWbGb8kSdKK1GU48u+A3wauAaiqTwOP6PC6/YH1bc/ZjcDpwGGjFarq3HbSP8D5wK4d45YkSVrROi3WWlVXzSm6ucPLdgFGX7ehLVvIMcDZXeKRJEla6bbtUOeqJA8Dql2k9XnA5xcziCRPBdYCBy5w/FjgWIDdd999MS8tSZI0iC49YX8APIemF+tqYL92f5Krgd1G9ndty35GkoOAFwOHVtUN852oqk6pqrVVtXbnnXfucGlJkqTlbWJPWFVtpFkjbHNdCOydZE+a5OsI4KjRCkkeALwBOLiqvrUF15AkSVqRFkzCkrwWqIWOT1qmoqpuSnIc8CGaxV3f1K4zdiIwW1XrgFcCOwLvSQLw1XY5DEmSpKk2ridstv3312iWmHhXu/8k4LIuJ6+qs4Cz5pS9ZGT7oM6RSpIkTZEFk7CqegtAkmcDD6+qm9r91wMfX5rwJEmSplOXifl3Be48sr9jWyZJkqQt1GWJipOAi5OcC4RmodaX9hmUJEnStOtyd+Sbk5wNHEAzUf+FVfWN3iOTJEmaYl16wqB5BNGvt9sFvL+fcCRJklaHLg/wPolmlfzL2q/jk/x134FJkiRNsy49YY8F9quqWwCSvAW4GHhRn4FJkiRNs04P8AbuMrK9Uw9xSJIkrSpdesL+htveHXlCr1FJkiRNuS53R74zyXnAg9si746UJEnaSl2HI28HbASuBe6T5BG9RSRJkrQKTOwJS/Jy4MnApcAtbXEBH+sxLkmSpKnWZU7YE4B9quqGnmORJElaNboMR14BbNd3IJIkSatJl56w64FLkpwD/LQ3rKqO7y0qSZKkKdclCVvXfkmSJGmRdFmi4i1LEYgkSdJq0nWJCkmSJC0ikzBJkqQBmIRJkiQNYMEkLMk2Sf5Xkv+b5NfmHPuz/kOTJEmaXuN6wt4AHAhcA/xDklePHHtir1FJkiRNuXFJ2P5VdVRV/R1wALBjkvcmuT2QJYlOkiRpSo1LwrbftFFVN1XVscAlwEeAHXuOS5IkaaqNS8Jmkxw8WlBVJwJvBmb6DEqSJGnaLZiEVdVTq+qD85T/S1X5LElJkqStMHbF/CT7A1VVFybZFzgY+EJVnbUk0UmSNsvMCWcueOzKkw5ZwkgkTbJgEpbkL4DHANsm+TDN5PxzgROSPKCqXrZEMUqSJE2dcT1hhwP7AbcHvgHsWlXfS/K3wAWASZgkSdIWGjcx/6aqurmqrge+VFXfA6iqHwG3LEl0kiRJU2pcEnZjkju02w/aVJhkJ0zCJEmStsq44chHVNUNAFU1mnRtBxzda1SSVrTVMDl8NbxHSf1aMAnblIDNU74R2NhbRJIkSavAuOFISZIk9WTsOmGSps9Cw2hLNYS2FNffkmuMG16UpD7YEyZJkjQAe8IkLWuL2UO1XHu7nOQvrU72hEmSJA3AJEySJGkADkdKIzZ3QvdqH0ZarsN7krQS2BMmSZI0AHvCtKwMvXzCUljM3qMt6aFbiL1ay9NSfF+m6edumt6Lpl+vPWFJDk5yeZL1SU6Y5/jtk7yrPX5Bkpk+45EkSVouekvCkmwDnAw8BtgXODLJvnOqHQN8t6ruDbwGeHlf8UiSJC0nfQ5H7g+sr6orAJKcDhwGXDZS5zDgpe32GcA/JklVVY9xaQut5m5+h+r6txraeJre41IMqy+V1fy7TcPqczhyF+Cqkf0Nbdm8darqJuA64O49xiRJkrQspK9OpySHAwdX1bPa/acBB1TVcSN1PtfW2dDuf6mts3HOuY4Fjm139wEu7yXoW60BNk6stbrZRuPZPpPZRuPZPpPZRuPZPpMtRRvtUVU7z3egz+HIq4HdRvZ3bcvmq7MhybbATsA1c09UVacAp/QU520kma2qtUt1vZXINhrP9pnMNhrP9pnMNhrP9pls6DbqczjyQmDvJHsm2R44Alg3p8464Oh2+3DgI84HkyRJq0FvPWFVdVOS44APAdsAb6qqS5OcCMxW1TrgjcBpSdYD36FJ1CRJkqZer4u1VtVZwFlzyl4ysv1j4El9xrCFlmzocwWzjcazfSazjcazfSazjcazfSYbtI16m5gvSZKkhfnsSEmSpAGYhEmSJA3AJEySJGkAJmGSJEkDMAmTJEkagEmYJEnSAEzCJEmSBmASJkmSNACTMEmSpAGYhEmSJA2g12dH9mHNmjU1MzMzdBiSJEkTXXTRRRurauf5jq24JGxmZobZ2dmhw5AkSZooyVcWOuZwpCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJA5iYhCW5Y5Lbtdv3SXJoku36D02SJGl6dekJ+xiwQ5JdgH8Hngac2mdQkiRJ065LEpaquh54IvC6qnoScN9+w5IkSZpunZKwJA8FngKc2ZZt019IkiRJ069LEvaHwJ8C76uqS5PcCzi316gkSZKm3LaTKlTVR4GPJrlDu38FcHzfgUmSJE2zLndHPjTJZcAX2v37J3ldl5MnOTjJ5UnWJzlhnuPPT3JZks8kOSfJHpv9DiRJklagLsORfwf8NnANQFV9GnjEpBcl2QY4GXgMsC9wZJJ951S7GFhbVfcDzgBe0TlySZKkFazTYq1VddWcops7vGx/YH1VXVFVNwKnA4fNOe+57Z2XAOcDu3aJR5IkaaXrkoRdleRhQCXZLsmfAJ/v8LpdgNHkbUNbtpBjgLM7nFeSJGnFmzgxH/gD4O9pEqiraRZsfc5iBpHkqcBa4MAFjh8LHAuw++67L+alJUmSBtHl7siNNGuEba6rgd1G9ndty35GkoOAFwMHVtUNC8RwCnAKwNq1a2sLYpEkSVpWFkzCkrwWWDDhqapJy1RcCOydZE+a5OsI4Kg513gA8Abg4Kr6VtegJUmSVrpxc8JmgYuAHYAHAv/Tfu0HbD/pxFV1E3Ac8CGaOWTvbhd7PTHJoW21VwI7Au9JckmSdVv6RiRJklaSVI0f3UtyPvDwNqkiyXbAx6vqIUsQ322sXbu2Zmdnh7i0JEnSZklyUVWtne9Yl7sj7wrceWR/x7ZMkiRJW6jL3ZEnARcnORcIzUKtL+0zKEmSpGnX5e7INyc5GziAZqL+C6vqG71HJkmSNMW69IRBs/r9r7fbBby/n3AkSZJWhy4P8D4JeB5wWft1fJK/7jswSZKkadalJ+yxwH5VdQtAkrfQPHj7RX0GJkmSNM06PcAbuMvI9k49xCFJkrSqdOkJ+xtue3fkCb1GJUmSNOW63B35ziTnAQ9ui7w7UpIkaSt1HY68HbARuBa4T5JH9BaRJEnSKjCxJyzJy4EnA5cCt7TFBXysx7gkSZKmWpc5YU8A9qmqG3qORZIkadXoMhx5BbBd34FIkiStJl16wq4HLklyDvDT3rCqOr63qCRJkqZclyRsXfslSZKkRdJliYq3LEUgkiRJq0nXJSokSZK0iEzCJEmSBmASJkmSNIAFk7AkxyVZ027fO8nHklyb5IIkv7p0IUqSJE2fcT1hz66qje323wOvqaq7AC8EXt93YJIkSdNsXBI2eufkz1fV+wCq6jzgTn0GJUmSNO3GJWFnJDk1yb2A9yX5wyR7JHkm8NUlik+SJGkqLbhOWFW9OMkzgHcCewG3B44F/g14ylIEJ0mSNK3GLtZaVacCpy5JJJIkSavI2CQsyf5AVdWFSfYFDga+UFVnLUl0krSCzZxw5rzlV550yBJHImk5WjAJS/IXwGOAbZN8GDgAOBc4IckDquplSxSjJEnS1BnXE3Y4sB/NXLBvALtW1feS/C1wAWASJkmStIXGJWE3VdXNwPVJvlRV3wOoqh8luWVpwpM0jRymk6TxS1TcmOQO7faDNhUm2QkwCZMkSdoK43rCHlFVNwBU1WjStR1wdK9RSdIiW6j3bSH2yknq27h1wm5YoHwjsHG+Y5IkSepm3HCkJEmSejJ2nTBJ2hqbOwS4XM693HgjgzSd7AmTJEkagD1h0jLRd2/H5vQcLXRNe2QkafHYEyZJkjQAkzBJkqQBOBwpLXNDrG+1mia9b67FaJuhhnUdTpaWF3vCJEmSBmASJkmSNACHI7UiOayivjkkOz9/9qTF02tPWJKDk1yeZH2SE+Y5fvsk72qPX5Bkps94JEmSloveesKSbAOcDDwa2ABcmGRdVV02Uu0Y4LtVde8kRwAvB57cV0xa3ub7H/ZQE5UX4qT3fq32XpbN/WwsVnsN8bO3GPp8/1tyHmlz9dkTtj+wvqquqKobgdOBw+bUOQx4S7t9BvCoJOkxJkmSpGWhzyRsF+Cqkf0Nbdm8darqJuA64O49xiRJkrQspKr6OXFyOHBwVT2r3X8acEBVHTdS53NtnQ3t/pfaOhvnnOtY4Nh2dx/g8l6CvtUaYOPEWqubbTSe7TOZbTSe7TOZbTSe7TPZUrTRHlW183wH+rw78mpgt5H9Xduy+epsSLItsBNwzdwTVdUpwCk9xXkbSWarau1SXW8lso3Gs30ms43Gs30ms43Gs30mG7qN+hyOvBDYO8meSbYHjgDWzamzDji63T4c+Ej11TUnSZK0jPTWE1ZVNyU5DvgQsA3wpqq6NMmJwGxVrQPeCJyWZD3wHZpETZIkaer1ulhrVZ0FnDWn7CUj2z8GntRnDFtoyYY+VzDbaDzbZzLbaDzbZzLbaDzbZ7JB26i3ifmSJElamM+OlCRJGoBJmCRJ0gBMwiRJkgZgEiZJkjQAkzBJkqQBmIRJkiQNwCRMkiRpACZhkiRJAzAJkyRJGkCvjy3qw5o1a2pmZmboMCRJkia66KKLNlbVzvMdW3FJ2MzMDLOzs0OHIUmSNFGSryx0zOFISZKkAZiESZIkDcAkTJIkaQAmYZIkSQMwCZMkSRqASZgkSdIATMIkSZIGYBImSZI0AJMwSZKkAZiESZIkDcAkTJIkaQAmYZIkSQMwCZMkSRqASZgkSdIATMIkSZIGsFlJWJK7JrlfX8FIkiStFhOTsCTnJblzkrsBnwL+Ocmr+w9NkiRpenXpCdupqr4HPBF4a1UdABzUb1iSJEnTrUsStm2SewC/B3yg53gkSZJWhS5J2InAh4AvVdWFSe4F/E+/YUmSJE23bSdVqKr3AO8Z2b8C+N0+g5IkSZp2XSbm3yfJOUk+1+7fL8mfdTl5koOTXJ5kfZIT5jn+/CSXJflMe409Nv8tSJIkrTxdhiP/GfhT4CcAVfUZ4IhJL0qyDXAy8BhgX+DIJPvOqXYxsLaq7gecAbyie+iSJEkrV5ck7A5V9ck5ZTd1eN3+wPqquqKqbgROBw4brVBV51bV9e3u+cCuHc4rSZK04nVJwjYm2QsogCSHA1/v8LpdgKtG9je0ZQs5Bji7w3klSZJWvIkT84HnAKcAv5TkauDLwFMXM4gkTwXWAgcucPxY4FiA3XfffTEvLUmSNIgud0deARyU5I7A7arq+x3PfTWw28j+rm3Zz0hyEPBi4MCqumGBGE6hSQRZu3Ztdby+JEnSsrVgEpbk+QuUA1BVkx5ddCGwd5I9aZKvI4Cj5pzrAcAbgIOr6lvdw5YkSVrZxvWE3an9dx/gwcC6dv/xwNyJ+rdRVTclOY5moddtgDdV1aVJTgRmq2od8EpgR+A9bXL31ao6dIveiSRJ0gqSqvGje0k+BhyyaRgyyZ2AM6vqEUsQ322sXbu2Zmdnh7i0JEnSZklyUVWtne9Yl7sjfwG4cWT/xrZMkiRJW6jL3ZFvBT6Z5H1AaNb6OrXPoCRJkqZdl7sjX5bkbODXadYKe2ZVXdx7ZJIkSVOsS08YwM3ALTRJ2C39hSNJkrQ6dHmA9/OAtwNrgJ8H3pbkuX0HJkmSNM269IQdAxxQVT8ESPJy4BPAa/sMTJIkaZp1uTsyNMORm9zclkmSJGkLdekJezNwQXt3JMATgDf2FpEkSdIq0OXuyFcn+Sjwa22Rd0dKkiRtpa53R14CfH1T/SS7V9VX+wpKkiRp2k1Mwto7If8C+Ca3zgcr4H79hiZJkjS9uvSEPQ/Yp6qu6TsYSZKk1aLL3ZFXAdf1HYgkSdJq0qUn7ArgvCRnAjdsKqyqV/cWlSRJ0pTrkoR9tf3avv2SJEnSVuqyRMVfLkUgkiRJq0mXOWGSJElaZCZhkiRJAzAJkyRJGsCCc8KSbAscA/wOcM+2+Grg/wFvrKqf9B+eJEnSdBo3Mf804FrgpcCGtmxX4GjgbcCT+wxMkiRpmo1Lwh5UVfeZU7YBOD/JF3uMSZIkaeqNmxP2nSRPSvLTOklul+TJwHf7D02SJGl6jUvCjgAOB76Z5Itt79c3gSe2xyRJkrSFFhyOrKoraed9Jbl7W+ZDvCVJkhZBl8cW/TT5SvLWqnp6vyFJkjbHzAlnzlt+5UmHLHEkkjbHuCUq1s0tAn4jyV0AqurQHuOSJEmaauN6wnYFLgP+BSiaJGwt8KoliEuSJGmqjUvC1gLPA14MvKCqLknyo6r66NKEJmkpOaQ1vz7bxTaXVrdxE/NvAV6T5D3tv98cV1+SJEndTUyqqmoD8KQkhwDf6z8kSX1bqAdmpbJHSdJK1Llnq6rOBKbrN7ckSdJAxi3WKkmSpJ44x0vSqjPf8OXmDl06BCppa9kTJkmSNACTMEmSpAE4HClpi6yE9bOm7S5QSdPFnjBJkqQB2BMmTQEniS8fK/V7sblxr9T3KS0n9oRJkiQNwCRMkiRpAA5HSsvQSp5Qvrmxb87wVZ/t0nebb875HeqTVodee8KSHJzk8iTrk5wwz/HbJ3lXe/yCJDN9xiNJkrRc9NYTlmQb4GTg0cAG4MIk66rqspFqxwDfrap7JzkCeDnw5L5i0vK0Uv/XvxImMi9G785y6iHS0ltO35/F+Blaqb9vNJ367AnbH1hfVVdU1Y3A6cBhc+ocBryl3T4DeFSS9BiTJEnSstBnErYLcNXI/oa2bN46VXUTcB1w9x5jkiRJWhZSVf2cODkcOLiqntXuPw04oKqOG6nzubbOhnb/S22djXPOdSxwbLu7D3B5L0Hfag2wcWKt1c02Gs/2mcw2Gs/2mcw2Gs/2mWwp2miPqtp5vgN93h15NbDbyP6ubdl8dTYk2RbYCbhm7omq6hTglJ7ivI0ks1W1dqmutxLZRuPZPpPZRuPZPpPZRuPZPpMN3UZ9DkdeCOydZM8k2wNHAOvm1FkHHN1uHw58pPrqmpMkSVpGeusJq6qbkhwHfAjYBnhTVV2a5ERgtqrWAW8ETkuyHvgOTaImSZI09XpdrLWqzgLOmlP2kpHtHwNP6jOGLbRkQ58rmG00nu0zmW00nu0zmW00nu0z2aBt1NvEfEmSJC3MZ0dKkiQNYFUnYR0eq/QHST6b5JIk/5lk3yHiHNKkNhqp97tJKsmquhOnw2foGUm+3X6GLknyrCHiHFKXz1CS30tyWZJLk7xjqWMcUofP0GtGPj9fTHLtAGEOqkMb7Z7k3CQXJ/lMkscOEedQOrTPHknOadvmvCS7DhHnUJK8Kcm32mWx5jueJP/Qtt9nkjxwyYKrqlX5RXOzwJeAewHbA58G9p1T584j24cCHxw67uXWRm29OwEfA84H1g4d93JqH+AZwD8OHesyb6O9gYuBu7b7Pz903MupfebUfy7NTU6Dx76c2ohmXs+z2+19gSuHjnuZtc97gKPb7d8EThs67iVuo0cADwQ+t8DxxwJnAwEeAlywVLGt5p6wiY9VqqrvjezeEVhtE+i6PHoK4P/SPPfzx0sZ3DLQtX1Wsy5t9PvAyVX1XYCq+tYSxzikzf0MHQm8c0kiWz66tFEBd263dwK+toTxDa1L++wLfKTdPnee41Otqj5GswLDQg4D3lqN84G7JLnHUsS2mpOwLo9VIslz2pX8XwEcv0SxLRcT26jttt2tqpbPU36XTqfPEPC7bRf3GUl2m+f4NOvSRvcB7pPkv5Kcn+TgJYtueF0/QyTZA9iTW/+YrhZd2uilwFOTbKC5I/+5SxPastClfT4NPLHd/h3gTkl8ROCtOv8cLrbVnIR1UlUnV9VewAuBPxs6nuUkye2AVwN/PHQsy9j7gZmquh/wYW59YL1utS3NkOQjaXp6/jnJXYYMaJk6Ajijqm4eOpBl6Ejg1KralWZo6bT295MafwIcmORi4ECap9X4OVoGVvOHtMtjlUadDjyhz4CWoUltdCfgV4DzklxJM5a+bhVNzp/4Gaqqa6rqhnb3X4AHLVFsy0WXn7MNwLqq+klVfRn4Ik1Sthpszu+hI1h9Q5HQrY2OAd4NUFWfAHageSbgatDl99DXquqJVfUA4MVt2bVLFuHyt7n5wKJZzUnYxMcqJRn9Q3AI8D9LGN9yMLaNquq6qlpTVTNVNUMzMf/QqpodJtwl1+UzNDqv4FDg80sY33LQ5fFl/0bTC0aSNTTDk1csYYxD6tI+JPkl4K7AJ5Y4vuWgSxt9FXgUQJJfpknCvr2kUQ6ny++hNSM9g38KvGmJY1zu1gFPb++SfAhwXVV9fSku3OuK+ctZdXus0nFJDgJ+AnyXW59zuSp0bKNVq2P7HJ/kUOAmmomhzxgs4AF0bKMPAb+V5DKaIZIXVNU1w0W9dDbjZ+wI4PRqb+VaTTq20R/TDGP/Ec0k/Weslrbq2D6PBP4mSdHcyf6cwQIeQJJ30rTBmnbe4F8A2wFU1etp5hE+FlgPXA88c8liWyWfU0mSpGVlNQ9HSpIkDcYkTJIkaQAmYZIkSQMwCZMkSRqASZgkSdIATMIkbbUkT0hS7XpWQ8VwzyRnLNK5npBk35H9E9vlarb2vI9Mcl2SS5J8IcnfDhWLpOGZhElaDEcC/9n+uyiSbNY6hu2q4Icv0uWfQPPQ403nfklV/ccinfvjVbUf8ADgcUl+bcBYJA3IJEzSVkmyI/BwmkfHHDFS/sgkH0tyZpLLk7x+06rdSX6Q5DVJLk1yTpKd2/LzkvxdklngeUkeleTiJJ9N8qYkt0/y4PaB6DskuWN7jl9JMpPkc+15npHk35J8OMmVSY5L8vz2XOcnuVtb7/eTXJjk00n+NckdkjyM5ukGr2x7rPZKcmqSw9vX3CamtvzKJH+Z5FPtsbG9glX1I+AS2gcFL2YsklYGkzBJW+sw4INV9UXgmiSjz8fcH3guTU/OXsAT2/I70qzmfV/gozQrWG+yfVWtBU4GTgWeXFW/SvOEj2dX1YU0jxn5K+AVwNuq6nPzxPUr7fUeDLwMuL59dt4ngKe3dd5bVQ+uqvvTPFLqmKr67/b8L6iq/arqS5tOmGSH+WIauebGqnog8E80D01eUJK70jwj82M9xSJpmTMJk7S1jqR5wD3tv6NDkp+sqiuq6maah08/vC2/BXhXu/22kXJGyvcBvtwmdwBvAR7Rbp8IPBpYS5OIzefcqvp+VX0buA54f1v+WWCm3f6VJB9P8lngKcB9J7zXcTEBvLf996KRa8z160k+TfOA4A9V1Td6ikXSMrdqnx0paeu1w3q/Cfxq+1y6bYBK8oK2ytznoi30nLTR8h92uPTdgR1pnv+2wwKvuWFk+5aR/Vu49XffqcATqurTSZ5B+yDxrbDpGjez8O/Xj1fV45LsCZyf5N1VdUkPsUha5uwJk7Q1DgdOq6o9qmqmqnYDvgz8ent8/yR7tnPBnkwzeR+a3z2bJtEfNVI+6nJgJsm92/2n0QxdArwB+HPg7cDLtyL+OwFfT7IdTe/TJt9vj21OTJulqr4MnAS8cOhYJA3DJEzS1jgSeN+csn/l1iHJC4F/pJnj9OWRuj+kSdA+R9OTduLcE1fVj4FnAu9ph+huAV6f5OnAT6rqHTRJzIOT/OYWxv/nwAXAfwFfGCk/HXhBO+l9r0kxbeG1aV/7iCQzyyAWSUssVQuNDkjSlkvySOBPqupx8xz7QVXtuORBSdIyYk+YJEnSAOwJkyRJGoA9YZIkSQMwCZMkSRqASZgkSdIATMIkSZIGYBImSZI0AJMwSZKkAfx/XXyHX94heFgAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 720x720 with 6 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, axes = plt.subplots(len(NUM_NODES_LIST), sharex=True, sharey=True)\n",
+    "\n",
+    "fig.set_size_inches(10, 10)\n",
+    "\n",
+    "for i, num_nodes in enumerate(NUM_NODES_LIST):\n",
+    "    axes[i].hist(magic_rounding_approximation_ratios[num_nodes], weights=np.zeros_like(magic_rounding_approximation_ratios[num_nodes]) + 1./TRIALS, bins=50)\n",
+    "    axes[i].set_ylabel(f\"{num_nodes} nodes\")\n",
+    "\n",
+    "fig.suptitle(\"QRAO (Magic Rounding) MaxCut Performance\")\n",
+    "plt.xlabel(\"Approximation Ratio\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These two graphs constitute the main results of [the paper](https://arxiv.org/pdf/2111.03167.pdf) (i.e. Fig. 1)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To summarize the information in the two graphs, we can additionally plot the median approximation ratio for Pauli rounding and magic rounding as a function of the number of nodes in the graph. This gives us a sense both of how well QRAO with Pauli rounding and with magic rounding each solve MaxCut overall, and how their performances change as the graph grows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAEWCAYAAAB8LwAVAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAA8ZklEQVR4nO3deXhV1dX48e9KAgmQAIEgUyRBBRkCBAggdULqgEOtqChQB7TqW/tqrVartlaQt/60VWttrdapzqKoVbFS57kFJGhkFEVNIBEhQAKBDGRYvz/2SbhcbpKTkJubG9bnec5z75nXPZCzzt77nH1EVTHGGGOCxUQ6AGOMMW2TJQhjjDEhWYIwxhgTkiUIY4wxIVmCMMYYE5IlCGOMMSFZgjDGGBOSJQhj2hEROVxEckSkRER+Eel4THSzBGF8EZFZIrJCREpF5HsRuU9EugXMnyMilSKyU0SKReS/IjIxxHYeE5EqEekbYt5pIvKJiOwSka0i8rSIpDYQ0xwRURG5Kmj6Vd70Ofv5s2u3N15EFnq/a5sX40U+131MRH7fyDLq/eadIlIgIn8Skdhmhvtr4D1VTVLVvzRzG8YAliCMDyLyK+APwHVAN+AIIB14U0Q6BCz6nKomAinAe8DzQdvpApwFbAfOC5p3NvAM8Gdv/eFABfCxiCQ3EN6XwAVB0y70pu83L8m9C3wAHAb0BC4HTm6J7QcY5R27HwIzgUubGGec9zUNWNWcAAK2YYyjqjbYUO8AdAV2AucETU8ECoELvfE5wFMB84cBCvQKmHYBsAG4ClgZMF2APODXQfuIAVYCc+uJbQ7wFLAGGO5NGw6s9qbP8aYlA//y4i3yvqd683oA+cCPAn7XOuACb/xj4G8NHJ9ZwMdB0xSXTC4DKoHd3jF8tZ5tKHBYwPjzwL3e99OAHKAY+C8wMmC5XOB6YDkumb4LVAPl3v4G4xL6E95vzwNuAmICYv8PcDewFfg98BhwH/Bvbxv/AfrgEncR8AUwOiCGG4CvgRLvuE8NPjbAnd663wInB8zvATwKfOfNfzlgXr2/24bWG6wEYRrzAyAB+GfgRFXdCSwETgxeQUQ64pLBVtwffq0LgXnAs8AQERnrTT8cGEBQiUNVa4AXgRMaifFJ9pQiLvTGA8XgTkRp3n7KgHu9fWwDLgYeEpGDcCfLHFV9QkQ6AxOBFxrZf0iq+iDwNPBHVU1U1R81to6IDAOOBj4TkdHAP4D/wZVcHgAWiEh8wCozgFOB7qo6GfgIuMLb35fAX3FJ4hDgWNxxCqwemwB8A/QGbvWmnYNLJCm4xLMI+NQbfwH4U8D6X3vxdgNuAZ4Kqj6cAKz11v0j8IiIiDfvSaAzLqnXHnt8/m7TCixBmMakAFtUtSrEvI1Ar4Dxc0SkGHcCvhQ4u3Y9ERkAHAc8o6qbgHfYc1JPCdheqH2khJge6ClghlfdNd0br6OqW1X1RVUtVdUS3Inw2ID5b+KS0zvAKbgTE7iSR0w9cbW0T0WkCHgVeBiX0C4DHlDVJaparaqP407YRwSs9xdV3aCqZcEb9NoxpgM3qmqJquYCdwHnByz2nar+VVWrArbxkqouU9Vy4CWgXFWfUNVq4DlgdO3Kqvq8qn6nqjWq+hzwFTA+YPt5qvqQt+7jQF+gt5dETgZ+pqpFqlqpqh946/j53aYVWIIwjdkCpNRTP93Xm19rvqp2x12NrgTGBsw7H1ijqjne+NPATO+kXruNfRquQ+xjH6q6Hlct9P+Ar1R1Q+B8EeksIg+ISJ6I7AA+BLoHNQQ/CGQAj6nqVm9aEVBTT1wtbYyqJqvqoap6k1d6SgN+5TWOF3vJ92CgX8B6G0JtzJMCdMBVLdXKA/o3sv6mgO9lIcYTa0dE5ALvrqna+DLYO6F/X/tFVUu9r4ne79imqoElzFp+frdpBZYgTGMW4a7ezgycKCKJuCvA94NXUNUtuKvAOQHVDRcAh3h3QH2Pq6ZIwV2xr8W1A0wL2kcMrlH7HR9xPgH8yvsM9itcNdYEVe0KHFO7C28/sbgE8QTwcxE5zPsdpd7vP6uB/e7CVZPUxtwnaP7+9Ke/AbhVVbsHDJ1VdZ7P7W/BtYGkBUwbABS0RHwikgY8BFwB9PQuDlbiHddGbAB6iEj3euY19rtNK7AEYRqkqttxdct/FZEpItJBRNKB+bgT0NP1rLcWeAP4tXcn0KG4qodMb8jA3bV0gaoqcC1wk4jMFJEE70T7MK6R/G4foT6Haw+ZH2JeEu7Kt1hEegCzg+b/BneivBi4A3gioHTxa2CWiFwnIj0BRGSUiDzrzf8cGC4imSKSgGs4D7QJV//fHA8BPxORCeJ0EZFTRSTJz8petc584FYRSfJO6NcQVAW3H7rgjlshgHfrb4bP2DbiGsLvE5Fk7/9VbeLer99tWo4lCNMoVf0j7iR6J+5ulW9xV83Hq+quBla9A1eSuBR4RVVXqOr3tQNwD3CaiPTw6q/PB67GNW6vBjoBRwZU+TQUY5mqvh2qLh53B04nXEJbDLxeO8NrKL8Gl6iqcbfzKu7uHFT1v8Bkb/hGRLbhShsLvflfAnOBt3H17x8H7fsRYJhXVfJyY78j6Ddl447dvbjqrnW4O4Oa4kpcKecbL7ZncA3A+01VV+PaNBbhEuEI3F1Pfp2PK+F8AWwGfulttyV+t2kB4i7ejPHPu1Kcizt5r490PMaY8LAEYZpFRM4HKlX12UYXNsZEJUsQxhhjQrI2CGOMMSG1m75XUlJSND09PdJhGGNMVFm2bNkWVe0Val67SRDp6elkZ2dHOgxjjIkqIpJX3zyrYjLGGBOSJQhjjDEhWYIwxhgTkiUIY4wxIVmCMMYYE5IlCGOMMSFZgjDGGBNSu3kOwhhjWsruqhq27qpgS8lutuysoHBnBVt2VpCU0IFx6ckMPiiJmBg/r72IbpYgjDEHhN1VNWzxTvRbdrqTf+2Jv7CkdrpLCMWllQ1uq2tCHGPTkslK78G49B6MTO1GQofYBteJRpYgjDFRq6Kq2p3USwJO/Dt3U1jiXfUHnPi3l4U+6SfGx5GS2JFeSfEMOiiRiYf0JCUxnpSkjqQkxtMrKZ5eifGkJMZTWFLB0txtZOdtY2luEe+tXQtAx9gYRqR2Iys9mXFpPRiblkxyl46teSjCot305pqVlaXW1YYx0W93VQ2bS8r3OfG7q/w9V/1bSirYUV4VchtJ8XGk1J7YvRP9nsElg9qT//5c+W/btZtleUVk520jO7eI5fnFVFa7c+qggxK9EkYy49J7kJrcCZG2Vy0lIstUNSvkvHAmCBGZgntrWCzwsKreHjQ/Dfd2q17ANuA8Vc335lUDK7xF16vq6Q3tyxJE66ioquaDtYXUKPTv3on+yZ1I7tyhTf7HN21TVXUNG7eXs6GolPxtZeQXlbKhyPvcVsamknJCnZaSEuLqruTdCd478SftOy1S1T3lldUsz9/uShm528jOK6LES2K9u8a7hOFVTQ3pk0RcbOTvE4pIgvDe6fslcALuhfRLgRneawprl3ke+JeqPi4ik4GLVPV8b95OVU30uz9LEOFVUFzGM0vyeG7pBrbs3L3XvIQOMfTr3skljO6d6OcNteN9uiXQMS7yfwimdVTXKJt2lJNfVMaGbaXus6i0LgF8v6Oc6po9550Ygb7d3MXGwcmdSU3uRN9uCXtO+knx9OzSMSrr+GtqlC83l7A0t8gljNwiCordW3G7dIxlTFoyWWmulJE5oDudO7Z+rX+kEsREYI6qnuSN3wigqrcFLLMKmKKqG8Rdgm5X1a7ePEsQEVZTo/zn6y08sSiPd9ZsAmDykN785IgBpHSJp6C4jO+Ky+o+3fdytuys2Gs7ItArMZ7+yXsSR79uCfRP7ky/7gn0796Jbp2sFBItVJXCnRVs8K7+gxPBd8VlddUstXp3jSc1uTMHJ3dynz28z+TOB9wFREFxWV2yWJq7jbWbSlCF2Bgho1/XumqpsWk96JUUH/Z4IpUgzsad/C/xxs8HJqjqFQHLPAMsUdV7RORM4EUgRVW3ikgVkANUAber6ssh9nEZcBnAgAEDxubl1dtrrWmC7aWVvPBpPk8tzuPbLbvo2aUj5447mJkTBpCa3LnR9csrq9m4vbwueRQUeQlkexnfFZdTUFzG7qqavdbp0jG2ruTRr3snUpM70a97Av26ufE+3RLo0AaK4wcCVaWotDLk1X9tQqgI+vdLSexI/5AJwP37RePVf2vZXlbJp+tdCWNpbhGfbyiuO74DU7qQlebaMLLSkxmY0qXFL6TacoLoB9wLDAQ+BM4CMlS1WET6q2qBiBwCvAv8UFW/rm9/VoLYfysLtvPU4jxezimgvLKGMQO6c8HEdE4e0Yf4uJb7A6+pUbbu2h1Q6ggshbgEsm3X3tVYMQK9uyYEVV8FjCd3omtChxaLsb3bXrYnAYQqBZTurt5r+e6dO5AaUAV0cI/OdeP9kztFpGqkvaqoqmZlwY66hLEsbxtF3m23Pbt0dHdKpfcgK70Hw/t13e8LpzZbxRS0fCLwhaqmhpj3GK6t4oX69mcJonkqqqpZuGIjTyzK47P1xSR0iOGMzP6cd0QaGf27RSyust3VXoljTwmkoHhPqWTj9n2rMZLi47yEkbB3dZb3eVBSfJtoFGwNuyqq6hqBN4RIACVBd/8kxsftc+KvHbfkG1k1Nco3W3Z6VVLujqm8raWAa/8bfXAyxwzuxeWTDm3W9iOVIOJwjdQ/BApwjdQzVXVVwDIpwDZVrRGRW4FqVb1ZRJKBUlWt8JZZBPw4sIE7mCWIpskvKuXpJet5bukGtu3azcCULpx3RBpnj02lW6e2fzKoqVG27KwIWfooKHLVWcEPO8XGCH26JnhJY+/SR20iSYyPjivh8srqPXf/7FUV5BJBUdBv79Qhtt4EkJpsbUDRZvOOcrLziry7pYpISezIoxeNb9a2Inmb6ynAn3G3uf5DVW8VkblAtqou8KqhbgMUV8X0v15S+AHwAFCD6y/qz6r6SEP7sgTRuJoa5aN1W3hyUS7vfrEZgOOH9ub8iWkceWhKu+s6YFdFFRu3l5Ff5JJHbZVWvvf5/fZyqmr2/v/fNSGO/smd966+CiqFtMZxqqiq5rvi8r3q/gNvBQ2+EaBjbAypyd6dQAFJoPZ7zy4dLQG0YzU12uz/lxFLEK3JEkT9ikt388Iy1+icu7WUlMSOTB83gBkTBtC/e6dIhxcx1TVKYUkFBcWlddVXtVVataWS4AexOsQKfbq5xvPa50D2JBKXVPzUxzf1WYC4GKlrvN+nHaBHZ3oltk7iMu1PQwkiOsrTpllW5G/nycW5vJLzHRVVNWSlJXP1CYOZktGyjc7RKjbGnez7dEtgbFroZUrKK+tKH8G39S75dhvff773Pf0AyZ07BJU+EijbXeP7WYAjD0vZJwH0PoDaT0zbYQminSmvrOa15Rt5cnEeORuK6dQhljPHpHL+EWkM69c10uFFnaSEDhzepwOH90kKOb+quoZNJRV7qq+K9jwTsn5rKYu+3srOij1P0qYmd2ZcevIB/yyAiQ6WINqJDdtKeWpJHvOXbqCotJJDenVh9o+GceaY6Gh0jlZxsTF1T4yHoqrsKK8iPi7GngUwUccSRBSrqVE++KqQJxfl8d7azcSIcILX6PyDQ3tao2QbICKWoE3UsgQRhYp27eb5ZRt4avF61m8rJSUxniuPO4wZEwbQt9uB2+hsjGlZliCiyOcbinlycR6vfu4ancen9+Dakw5nyvA+Vn9tjGlxliDauPLKal79/DueWpzH5/nb6dwxlrPHpnLeEWkM7WuNzsaY8LEE0Uat3+o1OmdvoLi0ksMOSuSW04dz5pj+JFm3B8aYVmAJog2prlE++HIzTyzK44MvC4kR4cRhrtF54iHW6GyMaV2WINqAbbt2Mz97A08vyWPDtjJ6JcVz5eRBzBw/gD7dEiIdnjHmAGUJIkJUlRyv0flfyzeyu6qGCQN7cP2UIZw0vI+9+8AYE3GWIFpZ2W7X6Pzk4jxWFGynS8dYzs06mPOOSKv3aV1jjIkESxCtJHfLLp5anMfzy/LZXlbJoIMS+b8fD+eM0dbobIxpmyxBhFF1jfLeF5t5YnEeH35ZSFyMcNLwPpw/MY0JA3tYo7Mxpk2zBBEGW3dW8Fz2Bp5evJ6C4jJ6d43nl8cPYsb4AfTuao3OxpjoYAmihagqn64v5qnFeby2fCO7q2uYeEhPfnvqUE4Y1tsanY0xUccSxH4q213NKzkFPLk4j1Xf7SAxPo4Z412j86De1uhsjIleliCa6ZvCnTy1eD0vLNvAjvIqDu+dxO/PyOCM0f2j5r3GxhjTEF9nMhHpDYzzRj9R1c3hC6ntqq5R3lmziScX5/HRV1uIixGmZPThgonpjEtPtkZnY0y70miCEJFzgDuA9wEB/ioi16nqC2GOrc0oLKlgfvYGnlniGp37dE3gmhMGM33cwRxkjc7GmHbKTwnit8C42lKDiPQC3gbadYJQVZblFfHk4jwWrthIZbVy5GE9+d1pQzl+aG97P7Axpt3zkyBigqqUtgK+zo4iMgW4B4gFHlbV24PmpwH/AHoB24DzVDXfm3chcJO36O9V9XE/+9xfpburePkz96Tzmo07SIqP4ycT0jjviDQOOyixNUIwxpg2wU+CeF1E3gDmeePnAgsbW0lEYoG/AScA+cBSEVmgqqsDFrsTeEJVHxeRycBtwPki0gOYDWQBCizz1i3y+8Oa6uvCnTy1OI8XluVTUl7FkD5J3Do1gzMy+9PFGp2NMQegRs98qnqdiJwFHOlNelBVX/Kx7fHAOlX9BkBEngV+DAQmiGHANd7394CXve8nAW+p6jZv3beAKexJUi3mu+Iyrnvhc/6zbisdYoWTM/py/sQ0stKs0dkYc2DzdWmsqi8CLzZx2/2BDQHj+cCEoGU+B87EVUNNBZJEpGc96/YP3oGIXAZcBjBgwIAmhuf06NKR7WWVXHviYM4dN4BeSfHN2o4xxrQ39SYIEflYVY8SkRJcNU/dLEBVtSXed3ktcK+IzAI+BAqAar8rq+qDwIMAWVlZ2sjiISV0iOVfVx7dnFWNMaZdqzdBqOpR3mdzHwcuAA4OGE/1pgXu4ztcCQIRSQTOUtViESkAJgWt+34z4zDGGNMMjd6NJCJP+pkWwlJgkIgMFJGOwHRgQdB2UkSkNoYbcXc0AbwBnCgiySKSDJzoTTPGGNNK/NyuOjxwRETigLGNraSqVcAVuBP7GmC+qq4Skbkicrq32CRgrYh8CfQGbvXW3Qb8Hy7JLAXm1jZYG2OMaR2iGrrqXkRuBH4DdAJKaycDu3F3Mt3YKhH6lJWVpdnZ2ZEOwxhjooqILFPVrFDz6i1BqOptXvvDHara1RuSVLVnW0sOxhhjWp6f5yBu9NoBBgEJAdM/DGdgxhhjIstPZ32XAFfh7iTKAY4AFgGTwxqZMcaYiPLTSH0VrqvvPFU9DhgNFIczKGOMMZHnJ0GUq2o5gIjEq+oXwOHhDcsYY0yk+elqI19EuuP6SXpLRIqAvHAGZYwxJvL8NFJP9b7OEZH3gG7Av8MalTHGmIhr0ltvVPUDoBwf3X0bY4yJbvUmCBGZLCJfishOEXlKREaISDbunQ33t16IxhhjIqGhEsRduK60e+JeL7oIeExVx6rqP1sjOGOMMZHTUBuEqur73veXRaRAVe9thZiMMca0AQ0liO4icmbgsoHjVoowxpj2raEE8QHwo4DxDwPGFbAEYYwx7VhDLwy6qDUDMcYY07Y06TZXY4wxBw5LEMYYY0KyBGGMMSYkP30xISI/ANIDl1fVJ8IUkzHGmDbAz/sgngQOxb0LotqbrIAlCGOMacf8lCCygGFa38urjTHGtEt+2iBWAn3CHYgxxpi2xU+CSAFWi8gbIrKgdvCzcRGZIiJrRWSdiNwQYv4AEXlPRD4TkeUicoo3PV1EykQkxxv+3rSfZYwxZn/5qWKa05wNi0gs8DfgBCAfWCoiC1R1dcBiNwHzVfV+ERmG60Y83Zv3tapmNmffxhhj9l+jJQjvHRBfAEnesMab1pjxwDpV/UZVdwPPAj8O3jzQ1fveDfjOb+DGGGPCq9EEISLnAJ8A04BzgCUicraPbfcHNgSM53vTAs0BzhORfFzp4cqAeQO9qqcPROToemK7TESyRSS7sLDQR0jGGGP88lPF9FtgnKpuBhCRXsDbuHdE7K8ZuHdM3CUiE4EnRSQD2AgMUNWtIjIW1934cFXdEbiyqj4IPAiQlZVld1kZY0wL8tNIHVObHDxbfa5XABwcMJ7qTQv0U2A+gKouAhKAFFWtUNWt3vRlwNfAYB/7NMYY00L8nOhf9+5gmiUis4DX8PdO6qXAIBEZKCIdgelA8N1P64EfAojIUFyCKBSRXl4jNyJyCDAI+MbPDzLGGNMyGq1iUtXrROQs4Ehv0oOq+pKP9apE5ArgDSAW+IeqrhKRuUC2qi4AfgU8JCJX4xqsZ6mqisgxwFwRqQRqgJ+p6rZm/UJjjDHNIu3lAemsrCzNzs6OdBjGGBNVRGSZqmaFmldvCUJEPlbVo0SkBHd1XzcL977qrvWsaowxph1o6I1yR3mfSa0XjjHGmLbCz3MQT/qZZowxpn3xcxfT8MAREYkDxoYnHGOMMW1FvQlCRG702h9GisgObygBNgGvtFqExhhjIqLeBKGqt3ntD3eoaldvSFLVnqp6YyvGaIwxJgL8PAdxo4gk4x5WSwiY/mE4AzPGGBNZfl45eglwFa6rjBzgCGARMDmskRljjIkoP43UVwHjgDxVPQ4YDRSHMyhjjDGR5ydBlKtqOYCIxKvqF8Dh4Q3LGGNMpPnp7jtfRLoDLwNviUgRkBfOoIwxxkSen0bqqd7XOSLyHu7Nb6+HNSpjTJtRWVlJfn4+5eXlkQ7F7IeEhARSU1Pp0KGD73X8lCDw7mI6GCjxhgzg0+YEaYyJLvn5+SQlJZGeno6IRDoc0wyqytatW8nPz2fgwIG+1/NzF9P/AbNw72Ooqd0fdheTMQeE8vJySw5RTkTo2bMnTX01s58SxDnAoaq6u1mRGWOiniWH6Necf0M/dzGtBLo3ecvGGNMCYmNjyczMJCMjg2nTplFaWtqs7SQmJgLw3XffcfbZZ+8zPzc3l06dOpGZmcmwYcO44IILqKys3K/YGzNnzhzuvPNOAG6++WbefvvtsO6vqfwkiNuAz7zXji6oHcIdmDHGAHTq1ImcnBxWrlxJx44d+fvf/75f2+vXrx8vvPBCyHmHHnooOTk5rFixgvz8fObPn79f+2qKuXPncvzxx7fa/vzwkyAeB/4A3A7cFTAYY0yrOvroo1m3bh2vvvoqEyZMYPTo0Rx//PFs2rQJ2PuKHCAjI4Pc3Ny9tpGbm0tGRkaD+4mNjWX8+PEUFBQA8M477zB69GhGjBjBxRdfTEVFBQDp6els2bIFgOzsbCZNmlQXx8UXX8ykSZM45JBD+Mtf/lK37VtvvZXBgwdz1FFHsXbt2rrps2bNqktc6enpzJ49mzFjxjBixAi++OILAAoLCznhhBMYPnw4l1xyCWlpaXX7Dwc/bRClqvqXxhczxrR3t7y6itXf7WjRbQ7r15XZPxre6HJVVVX8+9//ZsqUKRx11FEsXrwYEeHhhx/mj3/8I3fd1XLXreXl5SxZsoR77rmH8vJyZs2axTvvvMPgwYO54IILuP/++/nlL3/Z4Da++OIL3nvvPUpKSjj88MO5/PLLWb58Oc8++yw5OTlUVVUxZswYxo4N/faElJQUPv30U+677z7uvPNOHn74YW655RYmT57MjTfeyOuvv84jjzzSYr85FD8liI9E5DYRmSgiY2qHsEZljDGesrIyMjMzycrKYsCAAfz0pz8lPz+fk046iREjRnDHHXewatWqFtnX119/TWZmJr1796Zv376MHDmStWvXMnDgQAYPHgzAhRdeyIcfNt5X6amnnkp8fDwpKSkcdNBBbNq0iY8++oipU6fSuXNnunbtyumnn17v+meeeSYAY8eOrSsFffzxx0yfPh2AKVOmkJycvJ+/uGF+ShCjvc8jAqbZba7GHID8XOm3tNo2iEBXXnkl11xzDaeffjrvv/8+c+bMASAuLo6ampq65Zr6cF9tG8SWLVs48sgjWbBgAWlpafUuH7i/4H3Fx8fXfY+NjaWqqqpJsdSu35x1W0qjJQhVPS7E4Cs5iMgUEVkrIutE5IYQ8weIyHsi8pmILBeRUwLm3eitt1ZETmrazzLGtGfbt2+nf//+ADz++ON109PT0/n0U/cM76effsq3337brO2npKRw++23c9ttt3H44YeTm5vLunXrAHjyySc59thj6/a3bNkyAF588cVGt3vMMcfw8ssvU1ZWRklJCa+++mqT4jryyCPrGs7ffPNNioqKmrR+UzX0RrnzvM9rQg2NbVhEYoG/AScDw4AZIjIsaLGbgPmqOhqYDtznrTvMGx8OTAHu87ZnjDHMmTOHadOmMXbsWFJSUuqmn3XWWWzbto3hw4dz77331lULNccZZ5xBaWkpS5cu5dFHH2XatGmMGDGCmJgYfvaznwEwe/ZsrrrqKrKysoiNbfwUNWbMGM4991xGjRrFySefzLhx45oU0+zZs3nzzTfJyMjg+eefp0+fPiQlJTXr9/khqhp6hsj/qOoDIjI71HxVvaXBDYtMBOao6kne+I3eercFLPMA8I2q/sFb/i5V/UHwsiLyhretRfXtLysrS7OzsxsKyRjTDGvWrGHo0KGRDsMAFRUVxMbGEhcXx6JFi7j88sv3qX5rSKh/SxFZpqpZoZavtw1CVR/wPvdJBCLS0Ucs/YENAeP5wISgZeYAb4rIlUAXoPYm4P7A4qB1+4eI4zLgMoABAwb4CMkYY6LX+vXrOeecc6ipqaFjx4489NBDYd2fn76Y3gdmqWquNz4OeBgY1QL7nwE8pqp3eSWIJ0Wk4RuUA6jqg8CD4EoQLRCPMca0WYMGDeKzzz5rtf35uYvpNuB1EfkL7ir+ZOAiH+sV4HqArZXqTQv0U1wbA6q6SEQSgBSf6xpjjAkjP3cxvQH8DLgHuBg4RVX9dPW9FBgkIgO9KqnpQHAXHeuBHwKIyFAgASj0lpsuIvEiMhAYBHzi7ycZY4xpCX6qmH6H69H1GGAk8L6I/EpVX2toPVWtEpErgDeAWOAfqrpKROYC2aq6APgV8JCIXI17tmKWulbzVSIyH1gNVAH/q6rVzf+ZxhhjmspPFVNPYLyqlgGLROR1XBtEgwkCQFUXAguDpt0c8H01cGQ9694K3OojPmOMMWHgp4rpl0BXETlNRE4DylT1hLBHZowxuPcYnHfeeXXjVVVV9OrVi9NOO63Z2zzllFMoLi72texjjz1Gr169yMzMZMiQIdx9993N3q9fkyZNova2/abE2tIaTRAiMg1X/z8NV9W0RET27UzdGGPCoEuXLqxcuZKysjIA3nrrrbqnqJtr4cKFdO/e3ffy5557Ljk5OfznP//h1ltvZcOGDY2v1EKaGmtL8tNZ303AOFW9UFUvAMYDvwtvWMYYs8cpp5zCa6+5Wu158+YxY8aMunmffPIJEydOZPTo0fzgBz+o60K7tLSUc845h2HDhjF16lQmTJhQd1Ue2E33E088wciRIxk1ahTnn39+g3H07NmTww47jI0bNwLwpz/9iYyMDDIyMvjzn/8M7Nud+J133lnXV9SkSZO4/vrrGT9+PIMHD+ajjz4CXIeE06dPZ+jQoUydOrUuGQbGmpuby9ChQ7n00ksZPnw4J554Yt1yS5cuZeTIkWRmZnLdddc12p25X37aIGJUdXPA+Fb8JRZjTHvz7xvg+xUtu80+I+Dk2xtcZPr06cydO5fTTjuN5cuXc/HFF9edXIcMGcJHH31EXFwcb7/9Nr/5zW948cUXue+++0hOTmb16tWsXLmSzMzMfba7atUqfv/73/Pf//6XlJQUtm3b1mAc69evp7y8nJEjR7Js2TIeffRRlixZgqoyYcIEjj322EZ7WK2qquKTTz5h4cKF3HLLLbz99tvcf//9dO7cmTVr1rB8+XLGjAndYfZXX33FvHnzeOihhzjnnHN48cUXOe+887jooot46KGHmDhxIjfcsE+3d83m50T/uvc2uVkiMgvXOL2wkXWMMabFjBw5ktzcXObNm8cpp5yy17zt27czbdo0MjIyuPrqq+u6/g7sGjsjI4ORI0fus913332XadOm1fXn1KNHj5D7f+655xg5ciSHHXYYP//5z0lISODjjz9m6tSpdOnShcTERM4888y6pNWQUN14f/jhh3XtLCNHjgwZK8DAgQPrEl3t+sXFxZSUlDBx4kQAZs6c2WgMfjVYghD3luu/AOOAo7zJD6rqSy0WgTEmejRypR9Op59+Otdeey3vv/8+W7durZv+u9/9juOOO46XXnqJ3Nzcure6taRzzz2Xe++9l+zsbE488cQG3+PQWJfj+9ONd3AX4oFVUeHQYAnCeyZhoar+U1Wv8QZLDsaYVnfxxRcze/ZsRowYsdf0wK6/H3vssbrpgV1jr169mhUr9q0amzx5Ms8//3xdwmmsiikrK4vzzz+fe+65h6OPPpqXX36Z0tJSdu3axUsvvcTRRx9N79692bx5M1u3bqWiooJ//etfjf62Y445hmeeeQaAlStXsnz58kbXqdW9e3eSkpJYsmQJAM8++6zvdRvjp4rpU6//JWOMiZjU1FR+8Ytf7DP917/+NTfeeCOjR4/e64r85z//OYWFhQwbNoybbrqJ4cOH061bt73WHT58OL/97W859thjGTVqFNdc0+ibDLj++ut59NFHGTRoELNmzWL8+PFMmDCBSy65hNGjR9OhQwduvvlmxo8fzwknnMCQIUMa3ebll1/Ozp07GTp0KDfffHO9ryGtzyOPPMKll15KZmYmu3bt2ud3Nle93X3XLSDyBa6ri1xgFyC4wkXoSrIIse6+jQmPaO3uu7q6msrKShISEvj66685/vjjWbt2LR07+umMOrrs3LmTxMREAG6//XY2btzIPffcs89yLdbddwB7m5sxJuqUlpZy3HHHUVlZiapy3333tcvkAPDaa69x2223UVVVRVpa2l5Vbfuj0QShqnkiMgbXSK3Af3x21meMMRGTlJTEgVKrcO6553Luuee2+Hb9PEl9M/A4rk+mFOBREbmpxSMxxhjTpvipYvoJMEpVywFE5HYgB/h9GOMyxrQhqoq7691Eq8bam0PxcxfTd7j3NNSKx17eY8wBIyEhga1btzbrBGPaBlVl69atJCQkNL5wAD8liO249zO8hWuDOAH4xHvDHKq6731nxph2IzU1lfz8fAoLCyMditkPCQkJpKamNmkdPwniJW+o9X6T9mCMiWodOnRg4MCBkQ7DRICfu5ge914ZOgRXglirqrvDHpkxxpiI8vPK0VOAB4CvcQ/JDRSR/1HVf4c7OGOMMZHjp4rpT8BxqroOQEQOxfXoagnCGGPaMT93MZXUJgfPN0BJmOIxxhjTRvgpQWSLyEJgPq4NYhqwVETOBFDVf4YxPmOMMRHiJ0EkAJuAY73xQqAT8CNcwrAEYYwx7ZCfu5guCp4mIuNUdWlj64rIFOAeIBZ4WFVvD5p/N3CcN9oZOEhVu3vzqoHaDtzXq2r9b+gwxhjT4vyUIAAQkWHADG8oBkJ2DxuwfCzwN9yDdfm4aqkFqrq6dhlVvTpg+SuB0QGbKFPVTL/xGWOMaVmNvXI0nT1JoRJIA7JUNdfHtscD61T1G29bzwI/BlbXs/wMYLavqI0xxoRdvXcxicgi3O2sccBZqjoWd0dTrs9t9wc2BIzne9NC7SsNGAi8GzA5QUSyRWSxiJxRz3qXectkWzcAxhjTshq6zXUTkAT0Bnp508LVW9d04AVVrQ6Ylua95Wgm8Gfv+Yu9qOqDqpqlqlm9evUKnm2MMWY/1JsgVPUMYASwDJgjIt8CySIy3ue2C4CDA8ZTqb8X2OnAvKD9F3if3+D6fxq972rGGGPCpcEH5VR1u6o+qqonAhOA3wF3i8iGhtbzLAUGichAry+n6cCC4IVEZAiQDCwKmJYsIvHe9xTgSOpvuzDGGBMGvu9iUtXNwL3AvV6bQWPLV4nIFcAbuNtc/6Gqq0RkLpCtqrXJYjrwrO7d2fxQ4AERqcElsdsD734yxhgTftJeXgKSlZWlB8r7Z40xpqWIyDKvvXcffvpiMsYYcwCyBGGMMSYkP++D6AVcCqQHLq+qF4cvLGOMMZHmp5H6FeAj4G2gupFljTHGtBN+EkRnVb0+7JEYY4xpU/y0QfzLe+2oMcaYA4ifBHEVLkmUicgOESkRkR3hDswYY0xk+XkfRFJrBGKMMaZt8fUktYgkA4Nwb5cDQFU/DFdQxhhjIs/Pba6X4KqZUoEc4Ahcv0mTwxqZMcaYiPLbBjEOyFPV43C9qhaHMyhjjDGR5ydBlKtqOYCIxKvqF8Dh4Q3LGGNMpPlpg8gXke7Ay8BbIlIE5IUzKGOMMZHn5y6mqd7XOSLyHtANeD2sURljjIm4ehOEiHRV1R0i0iNg8grvMxHYFtbIjDHGRFRDJYhngNNwrxxVQALmKXBIGOMyxhgTYfUmCFU9zfsc2HrhGGOMaSsaqmIa09CKqvppy4djjDGmrWioiuku7zMByAI+x1UzjQSygYnhDc0YY0wk1fschKoe5z0YtxEYo6pZqjoW96BcQWsFaIwxJjL8PCh3uKrW3r2Eqq4EhoYvJGOMMW2BnwSxXEQeFpFJ3vAQsNzPxkVkioisFZF1InJDiPl3i0iON3wpIsUB8y4Uka+84ULfv8gYY0yL8PMk9UXA5bg+mQA+BO5vbCURiQX+BpwA5ANLRWSBqq6uXUZVrw5Y/kpc9RXesxezcW0fCizz1i3y86OMMcbsPz9PUpeLyN+Bhaq6tgnbHg+sU9VvAETkWeDHwOp6lp+BSwoAJwFvqeo2b923gCnAvCbs3xhjzH5otIpJRE7HdfP9ujeeKSILfGy7P7AhYDzfmxZqH2nAQODdpqwrIpeJSLaIZBcWFvoIyRhjjF9+2iBm40oDxQCqmoM7mbek6cALqlrdlJVU9UHv7qqsXr16tXBIxhhzYPOTICpVdXvQNPWxXgFwcMB4KvXfHjudvauPmrKuMcaYMPCTIFaJyEwgVkQGichfgf/6WG8pMEhEBopIR1wS2KdqSkSGAMm4t9TVegM4UUSSvdednuhNM8YY00r8JIgrgeFABe4qfwfwy8ZWUtUq4ArciX0NMF9VV4nIXK9do9Z04FlV1YB1twH/h0syS4G5tQ3WxhhjWocEnJejWlZWlmZnZ0c6DGOMiSoiskxVs0LNa6izvgbvVFLV0xuab4wxJro19BzERNytpvOAJez9PghjjDHtXEMJog/uKegZwEzgNWCeqq5qjcCMMcZEVkO9uVar6uuqeiFwBLAOeF9Ermi16FpDZTncfyS8Mxe2rIt0NMYY02Y02NWGiMQDp+JKEenAX4CXwh9WKyrdCl37wcd3w0d3Qep4yJwJw6dCp+6Rjs4YYyKm3ruYROQJIANYiLsNdWVrBtZU+30XU8n3sHw+5DwDhWsgNh6GngajZsKhx0FMbMsFa4wxbURDdzE1lCBqgF3eaOBCAqiqdm3RKPdTi93mqgobc1yiWPE8lBVBUl8YeY5LFgcN2f99GGNMG9GsBBFtwvIcRFUFfPkGfD4PvnoTaqqg3xhXBZVxFnTu0bL7M8aYVmYJoiXsLHQlipxnYNMKiO0Ih5/sShWHHQ+xfl6tYYwxbYsliJa2cbkrVSyfD6VboMtBrgoqcyb0Ht46MRhjTAuwBBEu1ZXw1Vvw+TOw9nWoqYQ+IyHzJzBiGnTp2brxGGNME1mCaA27tsLKFyHnadfIHRMHg6fAqBkw6ESI6xi52Iwxph6WIFrbptWuVLF8PuzcBJ17uhJF5kxXwhDrtcQY0zZYgoiU6ir4+l1Xqli7EKp3w0HDXaIYeQ4kHhTpCI0xBzhLEG1B6TZY9U/ImQcF2SCxMOgEVwV1+MkQFx/pCI0xB6BmdfdtWljnHjDuEjcUfumqoD5/Dr58HRK6w4izXcmi3xirgjLGtAlWgoikmmr45n13y+yaV6GqHHoNcaWKkedC176RjtAY085ZFVM0KN8Oq152D+JtWAwSA4dOdsliyKnQoVOkIzTGtEOWIKLN1q9dqSJnHuzIh/hukDHVPV+ROs6qoIwxLcYSRLSqqYHcj1ypYs0CqCyFnoe5UsWo6dAtNdIRGmOinCWI9qCiBFa/4koVeR8DAocc60oVQ06Djp0jHaExJgo1lCDqfaNcC+14ioisFZF1InJDPcucIyKrRWSViDwTML1aRHK8YUE444wK8Ukw+jy46DX4RQ5MugG2fQv/vBTuHAyvXAF5/3XdlRtjTAsIWwlCRGKBL3Hvtc4HlgIzVHV1wDKDgPnAZFUtEpGDVHWzN2+nqib63V+7L0GEUlMD6xe5KqjVL8PunZA8cE8VVHJapCM0xrRxkSpBjAfWqeo3qrobeBb4cdAylwJ/U9UigNrkYHyKiYH0I+GMv8G1X8LUB6D7AHj/NrhnJDx2mkseFTsjHakxJgqFM0H0BzYEjOd70wINBgaLyH9EZLGITAmYlyAi2d70M0LtQEQu85bJLiwsbNHgo07HLq7UcOEC+OUKmHwT7CiAly93VVAvXQ7ffuhKHcYY40Okn6SOAwYBk4BU4EMRGaGqxUCaqhaIyCHAuyKyQlW/DlxZVR8EHgRXxdSqkbdl3Q+GY66Do6+FDZ+4vqBWveSe3u42wCWSzBnQ45BIR2qMacPCmSAKgIMDxlO9aYHygSWqWgl8KyJf4hLGUlUtAFDVb0TkfWA08DXGPxEYMMENJ/8BvnjNVTl9eAd8+EcYMNF17zHsDEhoU68Yjw6q7u6ysqLQQ3mx970Y4hLck/FJAUPXvpDYBzokRPqXmGi0exd8vxK+X+5eL5B1UYvvIpyN1HG4Ruof4hLDUmCmqq4KWGYKruH6QhFJAT4DMoEaoFRVK7zpi4AfBzZwBzsgG6mba3sBLH/OPYy35UuI6wRDf+RKFQOPhZjYSEfYuqqr3JPsIU/uDQ3FoNX1b7dDZ+iUDAnd3DMsOzZCdcW+y3XqsSdhJPWBpH7us2u/PeNdUg68fxezR1mRe5Plxs9dQtj4OWz5CvDO36nj4JK3m7XpiHTWp6pVInIF8AYQC/xDVVeJyFwgW1UXePNOFJHVQDVwnapuFZEfAA+ISA2uneT2hpKDaaJu/eHoa+Coq6FgmStVrHwBVsyHrv1dP1CZMyFlUKQjbZrKcp8n9+K9v1dsb3i78d2gU3d3su+UDN0O3vM9cHrgkNB935KBqttnyUY37NgIJd9DyXfuc8d37opw5ybq/vBrSayXLPrsXQIJLpHEd7Un7aNdyfd7ksHGHJcQitfvmd+1P/QdBRlnuffL9B3lLibCwB6UM05lOXz5b5cs1r0NWuOuSjJnwvAz3YmwNai623X9ntwD51WV1b9diQ06iXcPfWIPPskndIPYVm6qq66CXZu9BLIxKKEEDOUhEluHzkEJJFSJpK91L98WqEJxnpcIAkoHOzftWabHodDXSwK1yaBLSouGYU9Sm6Yp+d69DS/nGShcA7HxrsPAzJlwyHH+Tpg11ftW2wSf0Ours6+pqn+7cQkhTubd9z2xBy8Tn9T+rqx37/JKIBv3lECCSyQl39dfrRWYMEKVSLr0crdSm/1XU+2qhGqrh2qTQW2Sl1jXk3PfUXsSQu+MVmkbtARhmkfVFXFz5rnqp7Ii16g6cpr7bKjOPtTVbaD4rv5O7MGJwHq1bZrAaq16SyTfh67WiomDxN5ewghqEwkct2qtvVVVwOY1e7cXbFrl2qHAXeT0Hr6nRNB3pHvTZIRuVrAEYfZf1W746g1XqvjqTXeVLzE+T+xBV/kJ3SC2Q6R/kQm0X9VaXfatwtqnRNKnfVZrVeyETSsDqog+h81fQE2lmx/fFfqM2LuKKGVw61dbNsAShGlZ5TsAhY5JVgVxoNmfaq3OPfdOGKFKJJ1TwvN/StW1q4Uaaqq97w0so9Vu/vYNAQ3In8PWddSVvDqn7F1F1Gek6/qmjf+N2CtHTcuyZyYOXB27QM9D3VAfP9Va3y+HnZsJXa3Vx/VOvM9JWkOc1EPM2+uk7n1vad0OdglgxLQ9CSGpb7urarMEYYxpWSLuHeyde7i69vpUV7m2j31KIBvd63clJsQgrkE35Dxvfkwj8/dn/S69XDLo3KP1jmcEWYIwxkRGbJx7Jqdbf2BspKMxIbTtyjFjjDERYwnCGGNMSJYgjDHGhGQJwhhjTEiWIIwxxoRkCcIYY0xIliCMMcaEZAnCGGNMSO2mLyYRKQTyIh2HJwXYEukgmimaY4fojj+aY4fojj+aY4f9iz9NVXuFmtFuEkRbIiLZ9XV+1dZFc+wQ3fFHc+wQ3fFHc+wQvvitiskYY0xIliCMMcaEZAkiPB6MdAD7IZpjh+iOP5pjh+iOP5pjhzDFb20QxhhjQrIShDHGmJAsQRhjjAnJEsR+EpF/iMhmEVkZMK2HiLwlIl95n8mRjLE+9cQ+R0QKRCTHG06JZIz1EZGDReQ9EVktIqtE5CpverQc+/rib/PHX0QSROQTEfnci/0Wb/pAEVkiIutE5DkR6RjpWENpIP7HROTbgGOfGeFQ6yUisSLymYj8yxsPy7G3BLH/HgOmBE27AXhHVQcB73jjbdFj7Bs7wN2qmukNC1s5Jr+qgF+p6jDgCOB/RWQY0XPs64sf2v7xrwAmq+ooIBOYIiJHAH/AxX4YUAT8NHIhNqi++AGuCzj2OZEK0IergDUB42E59pYg9pOqfghsC5r8Y+Bx7/vjwBmtGZNf9cQeFVR1o6p+6n0vwf2x9Cd6jn198bd56uz0Rjt4gwKTgRe86W352NcXf1QQkVTgVOBhb1wI07G3BBEevVV1o/f9e6B3JINphitEZLlXBdUmq2gCiUg6MBpYQhQe+6D4IQqOv1fFkQNsBt4CvgaKVbXKWySfNpzwguNX1dpjf6t37O8WkfjIRdigPwO/Bmq88Z6E6dhbgggzdfcRR83VCXA/cCiu6L0RuCui0TRCRBKBF4FfquqOwHnRcOxDxB8Vx19Vq1U1E0gFxgNDIhtR0wTHLyIZwI243zEO6AFcH7kIQxOR04DNqrqsNfZnCSI8NolIXwDvc3OE4/FNVTd5fzw1wEO4P/42SUQ64E6uT6vqP73JUXPsQ8UfTccfQFWLgfeAiUB3EYnzZqUCBZGKy6+A+Kd41X6qqhXAo7TNY38kcLqI5ALP4qqW7iFMx94SRHgsAC70vl8IvBLBWJqk9uTqmQqsrG/ZSPLqXR8B1qjqnwJmRcWxry/+aDj+ItJLRLp73zsBJ+DaUN4DzvYWa8vHPlT8XwRcWAiuDr/NHXtVvVFVU1U1HZgOvKuqPyFMx96epN5PIjIPmITrbncTMBt4GZgPDMB1QX6Oqra5xuB6Yp+Eq95QIBf4n4A6/TZDRI4CPgJWsKcu9je4evxoOPb1xT+DNn78RWQkriE0FneROV9V54rIIbir2h7AZ8B53tV4m9JA/O8CvQABcoCfBTRmtzkiMgm4VlVPC9extwRhjDEmJKtiMsYYE5IlCGOMMSFZgjDGGBOSJQhjjDEhWYIwxhgTkiUIE7VEREXkroDxa0VkTgtt+zERObvxJfd7P9NEZI2IvBc0Pd37fVcGTLtXRGY1YdvpEtBTrzFNZQnCRLMK4EwRSYl0IIECnmj146fApap6XIh5m4Gr2mq32ab9swRholkV7l28VwfPCC4BiMhO73OSiHwgIq+IyDcicruI/MR7P8AKETk0YDPHi0i2iHzp9YFT28nbHSKy1OvU7X8CtvuRiCwAVoeIZ4a3/ZUi8gdv2s3AUcAjInJHiN9XiOuy/MLgGSKSKSKLvRhequ3UT0TGinvPwefA/wYsX1/cfUXkQ3HvP1gpIkc3fMjNgcQShIl2fwN+IiLdmrDOKOBnwFDgfGCwqo7HdZ98ZcBy6bj+eE4F/i4iCbgr/u2qOg7XqdulIjLQW34McJWqDg7cmYj0w/XXPxn3lPQ4ETlDVecC2cBPVPW6emL9A3CtiMQGTX8CuF5VR+Kexp7tTX8UuNJ710Gg+uKeCbzhdVw3CvcEsTGAJQgT5bweUJ8AftGE1ZZ6HbNV4LqpftObvgKXFGrNV9UaVf0K+AbX0+eJwAVeV9FLcF0tD/KW/0RVvw2xv3HA+6pa6HXJ/DRwjM/f9423n5m107xk2F1VP/AmPQ4c4/Uv1N17zwfAkwGbqi/upcBFXtvNCO/dFMYA0JS6UmPaqj8Dn+KunmtV4V0AiUgMEFiPH9hHTU3AeA17/00E90OjuH56rlTVNwJneP3i7GpO8D78P9zLYD5obMEGhIwbQESOwZWSHhORP6nqE/uxH9OOWAnCRD2vM7757P2axVxgrPf9dNxbw5pqmojEeO0ShwBrgTeAy72uuhGRwSLSpZHtfAIcKyIpXlXRDJpwslfVL3DtGj/yxrcDRQHtBecDH3hdVxd7HQEC/CRgMyHjFpE0YJOqPoSrYhvjNy7T/lkJwrQXdwFXBIw/BLziNda+TvOu7tfjTu5dcT17lovIw7hqqE+9bqELaeT1jqq6UURuwHXJLMBrqtrU7phvxfXSWetCXLtIZ1z110Xe9IuAf4iIsqfqDNzJP1Tck4DrRKQS2Alc0MS4TDtmvbkaY4wJyaqYjDHGhGQJwhhjTEiWIIwxxoRkCcIYY0xIliCMMcaEZAnCGGNMSJYgjDHGhPT/AcU2Zd4xdPwxAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(NUM_NODES_LIST, [ np.median(pauli_rounding_approximation_ratios[num_nodes]) for num_nodes in NUM_NODES_LIST ], label=\"Pauli Rounding\")\n",
+    "plt.plot(NUM_NODES_LIST, [ np.median(magic_rounding_approximation_ratios[num_nodes]) for num_nodes in NUM_NODES_LIST ], label=\"Magic Rounding\")\n",
+    "plt.title(\"QRAO MaxCut Performance\")\n",
+    "plt.xlabel(\"Number of Nodes\")\n",
+    "plt.ylabel(\"Median Approximation Ratio\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "091032f753fd8b52e996fc03d6323ff523db19d64607db6acd8c3783811ef968"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.9.12 ('prototype-qrao')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
In this notebook, we evaluate the performance of QRAO by determining how closely it approximates the exact solution to MaxCut for 100 random 3-regular graphs. We also compare the performance of QRAO used with two different rounding schemes. In the process, we reproduce the main results of [the paper](https://arxiv.org/pdf/2111.03167.pdf) (i.e. Fig. 1).

### Details and comments
Running the magic rounding QRAO for a 40-node graph instance takes a while on my machine, so I've set the quantum instance that performs magic rounding to only do 1 shot. We can adjust this easily if necessary. Adding a section to the notebook that analyzes magic rounding QRAO performance (both approximation ratio and execution time) as a function of the number of shots of the rounding quantum instance could be also be interesting.
