### PR TITLE
Update requirements to not include notebook only dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,10 +43,10 @@ Any time you open a new shell and wish to work with QRAO, you will need to activ
 
 ## Install the QRAO prototype
 
-The following command will install the prototype, along with its required dependencies, in "editable" mode (don't forget the `.` after `-e`!). With this, local changes to the source files in your cloned repository will be reflected immediately in the installed environment.
+The following command will install the prototype, along with its required dependencies and those of the included notebooks, in "editable" mode (don't forget the `.` after `-e`!). With this, local changes to the source files in your cloned repository will be reflected immediately in the installed environment.
 
 ```sh
-$ pip install -e .
+$ pip install -e '.[notebook-dependencies]'
 ```
 
 ## Testing the Installation (optional)
@@ -79,6 +79,6 @@ Then, start the notebook server.  From the root directory:
 $ jupyter notebook
 ```
 
-Make sure the notebook server is started from the same Python environment (venv or conda) from which you ran `pip install -e .`; otherwise, it may not find `qrao` in the path.
+Make sure the notebook server is started from the same Python environment (venv or conda) from which you ran `pip install -e '.[notebook-dependencies]'`; otherwise, it may not find `qrao` in the path.
 
 Once the notebook server starts, it will provide a URL for accessing it through your web browser.  To find the tutorial notebooks, navigate in the browser to `docs` and then `tutorials`.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ git clone https://github.com/qiskit-community/prototype-qrao.git
 $ cd qrao
 $ python3 -m venv venv
 $ source venv/bin/activate
-$ pip install tox notebook -e .
+$ pip install tox notebook -e '.[notebook-dependencies]'
 $ jupyter notebook
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,10 @@ reno>=3.5.0
 # Black's formatting rules can change between major versions, so we use
 # the ~= specifier for it.
 black[jupyter]~=22.1
+
+# The following lines aren't strictly required by qrao if it is used as
+# a library, but they are required for one of the included Jupyter
+# notebooks, so we include them in this prototype's requirements for
+# convenience.
+cplex>=12.10
+tqdm[notebook]>=4.64

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,3 @@ qiskit-aer>=0.10.3
 qiskit-ibmq-provider>=0.18.3
 qiskit-optimization>=0.3.0
 matplotlib>=3.0.0
-
-# The following lines aren't strictly required by qrao if it is used as
-# a library, but they are required for one of the included Jupyter
-# notebooks, so we include them in this prototype's requirements for
-# convenience.
-cplex>=12.10
-tqdm[notebook]>=4.64

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("README.md", encoding="utf-8") as f:
 with open("requirements.txt") as f:
     install_requires = f.read().splitlines()
 
-tutorial_requirements = [
+notebook_requirements = [
     "cplex>=12.10",
     "tqdm[notebook]>=4.64",
 ]
@@ -52,6 +52,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.10",
     ],
     extra_require={
-        "tutorial": tutorial_requirements,
+        "notebook-dependencies": notebook_requirements,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,11 @@ with open("README.md", encoding="utf-8") as f:
 with open("requirements.txt") as f:
     install_requires = f.read().splitlines()
 
+tutorial_requirements = [
+    "cplex>=12.10",
+    "tqdm[notebook]>=4.64",
+]
+
 setuptools.setup(
     name="qrao",
     description="Quantum Random Access Optimization",
@@ -46,4 +51,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
+    extra_require={
+        "tutorial": tutorial_requirements,
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    extra_require={
+    extras_require={
         "notebook-dependencies": notebook_requirements,
     },
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the requirements list to only include required
packages for using qrao as a library. The requirements list get
installed unconditionally as part of installing the library meaning that
every user who tries to use qrao will get them installed too. Having
heavy and closed source dependencies like cplex in the list is
problematic for library users in particular because it makes it
difficult for any downstream consumers to depend on the package since it
will always pull those in. To avoid this issue this commit moves the
tutorial specific requirements into an optional extra requirement. This
then separates the concerns of library users and tutorial users. If you
run tutorials you can just run 'pip install prototyp-qrao[tutorials]'
which will install the library with the tutorials extras. At the same
time these dependencies are added to the requirements-dev.txt list too
so that tutorial dependencies are installed during documentation builds
too.


### Details and comments