### PR TITLE
Fix a bug in weighted magic rounding

### DIFF
--- a/qrao/magic_rounding.py
+++ b/qrao/magic_rounding.py
@@ -331,16 +331,16 @@ class MagicRounding(RoundingScheme):
             y = 0.5 * (1 - tv[dvars[1]]) if (len(dvars) > 1) else 0
             z = 0.5 * (1 - tv[dvars[2]]) if (len(dvars) > 2) else 0
             # ppp:   mu±   = .5(I ± 1/sqrt(3)( X + Y + Z))
-            # ppm: X mu± X = .5(I ± 1/sqrt(3)( X + Y - Z))
+            # pmm: X mu± X = .5(I ± 1/sqrt(3)( X - Y - Z))
             # mpm: Y mu± Y = .5(I ± 1/sqrt(3)(-X + Y - Z))
-            # pmm: Z mu± Z = .5(I ± 1/sqrt(3)( X - Y - Z))
+            # mmp: Z mu± Z = .5(I ± 1/sqrt(3)(-X - Y + Z))
             # fmt: off
             ppp_mmm =   x   *   y   *   z   + (1-x) * (1-y) * (1-z)
-            ppm_mmp =   x   *   y   * (1-z) + (1-x) * (1-y) *   z
-            mpm_pmp = (1-x) *   y   * (1-z) +   x   * (1-y) *   z
             pmm_mpp =   x   * (1-y) * (1-z) + (1-x) *   y   *   z
+            mpm_pmp = (1-x) *   y   * (1-z) +   x   * (1-y) *   z
+            ppm_mmp =   x   *   y   * (1-z) + (1-x) * (1-y) *   z
             # fmt: on
-            basis_probs.append([ppp_mmm, ppm_mmp, mpm_pmp, pmm_mpp])
+            basis_probs.append([ppp_mmm, pmm_mpp, mpm_pmp, ppm_mmp])
 
         bases = [
             [self.rng.choice(4, size=1, p=probs)[0] for probs in basis_probs]

--- a/tests/test_magic_rounding.py
+++ b/tests/test_magic_rounding.py
@@ -60,9 +60,9 @@ class TestMagicRounding(unittest.TestCase):
 
         self.deterministic_trace_vals = [
             [1, 1, 1],
-            [-1, -1, 1],
-            [1, -1, 1],
             [1, -1, -1],
+            [1, -1, 1],
+            [1, 1, -1],
         ]
 
         elist = [(0, 1), (0, 4), (0, 3), (1, 2), (1, 5), (2, 3), (2, 4), (4, 5), (5, 3)]
@@ -239,15 +239,8 @@ class TestMagicRounding(unittest.TestCase):
         magic = MagicRounding(quantum_instance=rounding_qi, basis_sampling="weighted")
         sample_bases_weighted = magic._sample_bases_weighted
 
-        stable_inputs = [
-            ([1, 1, 1], 0),
-            ([1, 1, -1], 1),
-            ([1, -1, 1], 2),
-            ([1, -1, -1], 3),
-        ]
-
-        for tv0, b0 in stable_inputs:
-            for tv1, b1 in stable_inputs:
+        for b0, tv0 in enumerate(self.deterministic_trace_vals):
+            for b1, tv1 in enumerate(self.deterministic_trace_vals):
                 tv = tv0 + tv1
                 bases, basis_shots = sample_bases_weighted(q2vars, tv)
                 self.assertTrue(np.all(np.array([b0, b1]) == bases))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This fixes a bug in the "weighted" sampling method for magic rounding as well as the corresponding bug in the tests.  The expressions are now consistent with [the paper](https://arxiv.org/abs/2111.03167) and with the other conventions used throughout magic rounding.

### Details and comments

