### PR TITLE
Fix #44, don't install cplex on M1 chip, where it is not available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("requirements.txt") as f:
     install_requires = f.read().splitlines()
 
 notebook_requirements = [
-    "cplex>=12.10",
+    "cplex>=12.10; platform_machine != 'arm64'",
     "tqdm[notebook]>=4.64",
 ]
 


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is my first candidate solution.

This will fix the install, but the first notebook will no longer run in this case, obviously.


### Details and comments

