### PR TITLE
Add retworkx as a direct dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ qiskit-terra>=0.19.2
 qiskit-aer>=0.10.3
 qiskit-ibmq-provider>=0.18.3
 qiskit-optimization>=0.3.0
-retworkx>=0.8.0
+retworkx>=0.10.1
 matplotlib>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ qiskit-terra>=0.19.2
 qiskit-aer>=0.10.3
 qiskit-ibmq-provider>=0.18.3
 qiskit-optimization>=0.3.0
+retworkx>=0.8.0
 matplotlib>=3.0.0


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We were previously importing retworkx from `encoding.py` without specifying it as a dependency, under the assumption that it would forever be a transitive dependency through qiskit-terra.  However, qiskit-terra has migrated to the package's new name, rustworkx, so under this arrangement the latest retworkx package, which is a backwards compatibility shim, is not installed.  This fixes the most immediate issue by adding retworkx as a direct dependency.

### Details and comments

