### PR TITLE
Modify `tox.ini` to work with tox 4

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -36,7 +36,7 @@ jobs:
           # Second, update requirements[-dev].txt in place to use the
           # development (git) versions of all Qiskit packages.
           sed -i 's|^\(qiskit[A-Za-z-]*\).*|git+https://github.com/Qiskit/\1.git|' requirements-dev.txt requirements.txt
-          pip install tox
+          pip install 'tox<4'
       - name: Modify tox.ini for more thorough check
         shell: bash
         run: |

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox
+          pip install 'tox<4'
       - name: Modify tox.ini for more thorough check
         shell: bash
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,9 @@
 minversion = 2.4
 envlist = py36, py37, py38, py39, py310, lint, coverage, docs
 # CI: skip-next-line
-skipsdist = true
-# CI: skip-next-line
 skip_missing_interpreters = true
 
 [testenv]
-# CI: skip-next-line
-usedevelop = true
 install_command = pip install -U {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

tox 4 has been released, and these modifications are necessary to get qrao to work with tox 4 locally.

UPDATE: I was unable to get tox 4 working on CI, so I have pinned `tox<4` for the workflows that were failing there in this same PR.



### Details and comments

With `skipsdist = true`, `importlib_metadata` would complain.

I don't understand fully why `usedevelop` had to go away. When it was set to `true`, `nbqa pylint` would fail because it was unable to import `qrao`.